### PR TITLE
Removed old Human Variant Feat

### DIFF
--- a/COM_5ePack_PHB - Races.user
+++ b/COM_5ePack_PHB - Races.user
@@ -135,29 +135,6 @@
       <autotag group="Usage" tag="AtWill"/>
       </bootstrap>
     </thing>
-  <thing id="ra5CHumVar" name="Obsolete - Variant Human - Obsolete" description="Humans in Toril are widespread, can be found in most regions and, in general, are fierce and disagreeable, which can sometimes lead certain other races to view them with contempt. They are renowned for their diversity and ambition, and although they lack specialization, they can excel in many areas." compset="SubRace" uniqueness="unique">
-    <usesource source="5ePHBCP"/>
-	<tag group="Helper" tag="Obsolete"/>
-    <tag group="RaceType" tag="Normal"/>
-    <tag group="RaceSize" tag="Medium0"/>
-    <tag group="SubRace" tag="rHuman"/>
-    <bootstrap thing="ra5CHuFeat"></bootstrap>
-    <bootstrap thing="ra5CHuV2A"></bootstrap>
-    <eval phase="First" priority="500"><![CDATA[
-      ~ If we're disabled, do nothing
-      doneif (tagis[Helper.Disable] <> 0)
-
-      hero.child[RaceHelper].field[cSkillMax].value += 1
-      hero.child[RaceHelper].field[cSkCandExp].text = "TRUE"
-
-      ~overwrite the human's default +1 to everything
-      hero.child[rHuman].field[rSTR].value = 0
-      hero.child[rHuman].field[rDEX].value = 0
-      hero.child[rHuman].field[rCON].value = 0
-      hero.child[rHuman].field[rINT].value = 0
-      hero.child[rHuman].field[rWIS].value = 0
-      hero.child[rHuman].field[rCHA].value = 0]]></eval>
-    </thing>
   <thing id="ra5CHuV2A" name="Select Two Attributes To Increase By One." description="Placeholder..." compset="RaceSpec">
     <usesource source="5ePHBCP"/>
     <tag group="fShowWhat" tag="Attributes"/>


### PR DESCRIPTION
Use of the Obsolete tag with the Human Variant was resulting in a validation error for people using the new feat as it thought a Sub-Race still needs to be picked. Have removed the old Human Variant thing completely (ra5CHumVar). 

<thing id="ra5CHumVar" name="Obsolete - Variant Human - Obsolete" description="Humans in Toril are widespread, can be found in most regions and, in general, are fierce and disagreeable, which can sometimes lead certain other races to view them with contempt. They are renowned for their diversity and ambition, and although they lack specialization, they can excel in many areas." compset="SubRace" uniqueness="unique">
    <usesource source="5ePHBCP"/>
	<tag group="Helper" tag="Obsolete"/>
    <tag group="RaceType" tag="Normal"/>
    <tag group="RaceSize" tag="Medium0"/>
    <tag group="SubRace" tag="rHuman"/>
    <bootstrap thing="ra5CHuFeat"></bootstrap>
    <bootstrap thing="ra5CHuV2A"></bootstrap>
    <eval phase="First" priority="500"><![CDATA[
      ~ If we're disabled, do nothing
      doneif (tagis[Helper.Disable] <> 0)

      hero.child[RaceHelper].field[cSkillMax].value += 1
      hero.child[RaceHelper].field[cSkCandExp].text = "TRUE"

      ~overwrite the human's default +1 to everything
      hero.child[rHuman].field[rSTR].value = 0
      hero.child[rHuman].field[rDEX].value = 0
      hero.child[rHuman].field[rCON].value = 0
      hero.child[rHuman].field[rINT].value = 0
      hero.child[rHuman].field[rWIS].value = 0
      hero.child[rHuman].field[rCHA].value = 0]]></eval>
    </thing>