### PR TITLE
Update COM_5ePack_PHB - Classes.user

### DIFF
--- a/COM_5ePack_PHB - Classes.user
+++ b/COM_5ePack_PHB - Classes.user
@@ -2134,7 +2134,7 @@
         perform focus.assign[sClass.cHelpWiz]
 
         ~ Cantrip Array
-        focus.field[cArrKnCan].arrayvalue[2] += 3
+        focus.field[cArrKnCan].arrayvalue[2] += 2
         focus.field[cArrKnCan].arrayvalue[9] += 4
 
         ~ Spells Known Array


### PR DESCRIPTION
Modified Rogue (Arcane Tricker) was giving 1x too many Cantrips. #97 
Rogue Spells tab does not display Mage Hand. Assume this is because the spell is bootstrapped in and therefore it's not designed to display on the Rogue Spells tab.