### PR TITLE
Daplunk   spare the dying duplication

### DIFF
--- a/COM_5ePack - Deprecated Things.user
+++ b/COM_5ePack - Deprecated Things.user
@@ -22,6 +22,17 @@
     <tag group="sComp" tag="M"/>
     <tag group="sLevel" tag="1"/>
     </thing>
+	  <thing id="sp5CSpareD" name="Deprecated - Spare the Dying" description="You touch a living creature that has 0 hit points. The creature becomes stable. This spell has no effect on undead or constructs." compset="Spell">
+    <fieldval field="sRange" value="Touch"/>
+    <usesource source="5ePHBCP"/>
+    <tag group="sLevel" tag="0"/>
+    <tag group="sCastTime" tag="Action1"/>
+    <tag group="sClass" tag="cHelpClr"/>
+    <tag group="sSchool" tag="Necromancy"/>
+    <tag group="sComp" tag="S"/>
+    <tag group="sDuration" tag="Instant"/>
+    <tag group="sComp" tag="V"/>
+    </thing>
   <thing id="sp5CVicioM" name="Deprecated - Vicious Mockery" description="You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a W isdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.\n\nThis spell’s damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4)." compset="Spell">
     <fieldval field="sRange" value="60 feet"/>
     <fieldval field="sTarget" value="a creature you can see within range"/>

--- a/COM_5ePack_SCAG - Classes.user
+++ b/COM_5ePack_SCAG - Classes.user
@@ -211,7 +211,7 @@ doneif (#levelcount[Wizard] < 14)
     </thing>
   <thing id="c5CWlkAmtD" name="Among the Dead" description="You learn the spare the dying cantrip, as a warlock cantrip. You have advantage on saving throws against any disease.\n\If an undead targets you directly a a harmful spell or an attack, it must make a Wisdom saving throw against your spell save DC or it must choose a new target or forfeit targeting someone instead of you. If it succeeds on the save, or you target it with an attack or a harmful spell, it is immune to this effect for 24 hours." compset="ClSpecial">
     <tag group="abAction" tag="None"/>
-    <bootstrap thing="sp5CSpareD">
+    <bootstrap thing="spSparDyi">
       <autotag group="Helper" tag="Free"/>
       <autotag group="Helper" tag="Memorized"/>
       <autotag group="BonusSplAt" tag="1"/>


### PR DESCRIPTION
#329 - Community copy of Spare the Dying moved to deprecated. 

Warlock > Otherwordly Patrons > The Undying - updated to use new official Spare the Dying. 