### PR TITLE
SCAG - Resolved Extra Attack Display Bug

### DIFF
--- a/COM_5ePack_SCAG - Classes.user
+++ b/COM_5ePack_SCAG - Classes.user
@@ -19,7 +19,7 @@
     <bootstrap thing="c5CWizBlS">
       <autotag group="ClSpecWhen" tag="2"/>
       </bootstrap>
-    <bootstrap thing="cExtraAtt">
+    <bootstrap thing="c5CWizExAt">
       <autotag group="ClSpecWhen" tag="6"/>
       <assignval field="CustDesc" value="Beginning at 6th level, you can attack twice, instead of once, whenever you take the Attack action on your turn."/>
       </bootstrap>
@@ -1567,5 +1567,20 @@ endif
     <tag group="wCategory" tag="Melee"/>
     <tag group="wProperty" tag="Special"/>
     <tag group="wProfReq" tag="Special"/>
+    </thing>
+  <thing id="c5CWizExAt" name="Extra Attack" description="Starting at 6th level, you can attack twice, instead of once, whenever you take the Attack action on your turn." compset="ClSpecial" summary="You can make an extra attack when you take the Attack action.">
+    <tag group="abAction" tag="None" name="No action" abbrev="None"/>
+    <tag group="abDuration" tag="Constant" name="Constant" abbrev="cons"/>
+    <tag group="abRange" tag="Personal" name="Personal" abbrev="pers"/>
+    <eval phase="PostLevel" priority="20000"><![CDATA[
+      doneif (tagis[Helper.ShowSpec] = 0)
+
+      doneif (tagis[Helper.Disable] <> 0)
+
+      ~If we're not already getting an extra attack, assign the extra attack tag
+      doneif (hero.tagis[Hero.ExtraAtt] <> 0)
+      perform hero.assign[Hero.ExtraAtt]]]>
+      <after name="Fighter extra attacks"/>
+      </eval>
     </thing>
   </document>


### PR DESCRIPTION
#274 - SCAG - Resolved Extra Attack Display Bug

Was using the same Extra Attack special as the Monk which caused it to proc at L5 when multi-classed with a Monk.