### PR TITLE
fix superiority dice

### DIFF
--- a/COM_5ePack_PHB - Classes.user
+++ b/COM_5ePack_PHB - Classes.user
@@ -1146,7 +1146,7 @@
     <fieldval field="abValue" value="1"/>
     <fieldval field="abValue2" value="8"/>
     <fieldval field="trkMax" value="4"/>
-    <tag group="Usage" tag="Battle"/>
+    <tag group="Usage" tag="ShortRest"/>
     <tag group="User" tag="Tracker"/>
     <tag group="abAction" tag="None"/>
     <tag group="abRange" tag="Personal"/>


### PR DESCRIPTION
The vsuperiority dice for some reason was set to reset once per "battle"
when in fact it resets per short rest. Fixed it