### PR TITLE
#497 - Fixed innate spell casting for Yuan-Ti Pureblood.

### DIFF
--- a/COM_5ePack_VGtM - Races.user
+++ b/COM_5ePack_VGtM - Races.user
@@ -473,8 +473,10 @@
       <autotag group="Helper" tag="RaceSpell"/>
       </bootstrap>
     <bootstrap thing="spSuggesti">
-      <autotag group="Usage" tag="LongRest"/>
+      <containerreq phase="First" priority="500"><![CDATA[(count:Classes.? >= 3)]]></containerreq>
       <autotag group="Helper" tag="RaceSpell"/>
+      <autotag group="Usage" tag="LongRest"/>
+      <assignval field="trkMax" value="1"/>
       </bootstrap>
     <bootstrap thing="ra5CMagRes"></bootstrap>
     <bootstrap thing="ra5CPoiImm"></bootstrap>


### PR DESCRIPTION
#497 - Fixed innate spell casting for Yuan-Ti Pureblood.