### PR TITLE
Artificer

### DIFF
--- a/COM_5ePack_UA - Artificer.user
+++ b/COM_5ePack_UA - Artificer.user
@@ -1,0 +1,717 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document signature="Hero Lab Data">
+  <thing id="cHelpArt" name="Artificer" description="Makers of magic-infused objects, artificers are defined by their inventive nature. Like wizards, they see magic as a complex system waiting to be decoded and controlled through a combination of thorough study and investigation.\nArtificers, though, focus on creating marvelous new magical objects. Spells are often too ephemeral and temporary for their tastes.  Instead, they seek to craft durable, useful items." compset="Class" uniqueness="unique">
+    <fieldval field="cHDSides" value="8"/>
+    <fieldval field="cAbbr" value="Art"/>
+    <fieldval field="cSkillMax" value="3"/>
+    <fieldval field="cToolMax" value="2"/>
+    <fieldval field="StartWeap" value="•  (a) a handaxe and a light hammer or  (b) any two simple weapons{br}•  a light crossbow and 20 bolts"/>
+    <fieldval field="StartArmor" value="•  (a) scale mail or  (b) studded leather armor"/>
+    <fieldval field="StartGear" value="•  thieves’ tools and a dungeoneer’s pack"/>
+    <fieldval field="StartAll" value="•  (a) a handaxe and a light hammer or  (b) any two simple weapons{br}•  a light crossbow and 20 bolts{br}•  (a) scale mail or  (b) studded leather armor{br}•  thieves’ tools and a dungeoneer’s pack"/>
+    <fieldval field="cSpecSing" value="Artificer Specialist"/>
+    <arrayval field="cArrKnSpl" index="3" value="4"/>
+    <arrayval field="cArrKnSpl" index="4" value="4"/>
+    <arrayval field="cArrKnSpl" index="5" value="4"/>
+    <arrayval field="cArrKnSpl" index="6" value="5"/>
+    <arrayval field="cArrKnSpl" index="7" value="6"/>
+    <arrayval field="cArrKnSpl" index="8" value="6"/>
+    <arrayval field="cArrKnSpl" index="9" value="7"/>
+    <arrayval field="cArrKnSpl" index="10" value="8"/>
+    <arrayval field="cArrKnSpl" index="11" value="8"/>
+    <arrayval field="cArrKnSpl" index="12" value="9"/>
+    <arrayval field="cArrKnSpl" index="13" value="10"/>
+    <arrayval field="cArrKnSpl" index="14" value="10"/>
+    <arrayval field="cArrKnSpl" index="15" value="11"/>
+    <arrayval field="cArrKnSpl" index="16" value="11"/>
+    <arrayval field="cArrKnSpl" index="17" value="11"/>
+    <arrayval field="cArrKnSpl" index="18" value="12"/>
+    <arrayval field="cArrKnSpl" index="19" value="13"/>
+    <arrayval field="cArrKnLev" index="2" value="1"/>
+    <arrayval field="cArrKnLev" index="3" value="1"/>
+    <arrayval field="cArrKnLev" index="4" value="1"/>
+    <arrayval field="cArrKnLev" index="5" value="1"/>
+    <arrayval field="cArrKnLev" index="6" value="2"/>
+    <arrayval field="cArrKnLev" index="7" value="2"/>
+    <arrayval field="cArrKnLev" index="8" value="2"/>
+    <arrayval field="cArrKnLev" index="9" value="2"/>
+    <arrayval field="cArrKnLev" index="10" value="2"/>
+    <arrayval field="cArrKnLev" index="11" value="2"/>
+    <arrayval field="cArrKnLev" index="12" value="3"/>
+    <arrayval field="cArrKnLev" index="13" value="3"/>
+    <arrayval field="cArrKnLev" index="14" value="3"/>
+    <arrayval field="cArrKnLev" index="15" value="3"/>
+    <arrayval field="cArrKnLev" index="16" value="3"/>
+    <arrayval field="cArrKnLev" index="17" value="3"/>
+    <arrayval field="cArrKnLev" index="18" value="4"/>
+    <arrayval field="cArrKnLev" index="19" value="4"/>
+    <arrayval field="cCustTot" index="0" value="1"/>
+    <arrayval field="cArrKnSpl" index="2" value="3"/>
+    <arrayval field="cAttrArray" index="3" value="2"/>
+    <arrayval field="cAttrArray" index="7" value="2"/>
+    <arrayval field="cAttrArray" index="11" value="2"/>
+    <arrayval field="cAttrArray" index="15" value="2"/>
+    <arrayval field="cAttrArray" index="17" value="2"/>
+    <usesource source="p5eArtUACP" parent="p5eUneArc" name="5e Unearthed Arcana - Artificer"/>
+    <tag group="AllowSkl1" tag="skArcana"/>
+    <tag group="AllowSkl1" tag="skDecept"/>
+    <tag group="AllowSkl1" tag="skHistory"/>
+    <tag group="AllowSkl1" tag="skInvestig"/>
+    <tag group="AllowSkl1" tag="skMedicine"/>
+    <tag group="AllowSkl1" tag="skNature"/>
+    <tag group="AllowSkl1" tag="skReligion"/>
+    <tag group="ProfSave" tag="svCON"/>
+    <tag group="ProfSave" tag="svINT"/>
+    <tag group="ArmProfGrp" tag="ArmorLight"/>
+    <tag group="ArmProfGrp" tag="ArmorMed"/>
+    <tag group="AllowSkl1" tag="skSleight"/>
+    <tag group="PrimeAbil" tag="aINT"/>
+    <tag group="AllowTool1" tag="gSupAlchem"/>
+    <tag group="AllowTool1" tag="Artisan"/>
+    <tag group="AllowTool1" tag="gSupBrewer"/>
+    <tag group="AllowTool1" tag="gSupCaligr"/>
+    <tag group="AllowTool1" tag="gTooCarpen"/>
+    <tag group="AllowTool1" tag="gTooCartog"/>
+    <tag group="AllowTool1" tag="gTooCobble"/>
+    <tag group="AllowTool1" tag="gUtenCook"/>
+    <tag group="AllowTool1" tag="gKitDisgui"/>
+    <tag group="AllowTool1" tag="gTooGlassb"/>
+    <tag group="AllowTool1" tag="gKitHerbal"/>
+    <tag group="AllowTool1" tag="gTooJewele"/>
+    <tag group="AllowTool1" tag="gVehLand"/>
+    <tag group="AllowTool1" tag="gTooLeathe"/>
+    <tag group="AllowTool1" tag="gTooMason"/>
+    <tag group="AllowTool1" tag="gTooNaviga"/>
+    <tag group="AllowTool1" tag="gSupPainte"/>
+    <tag group="AllowTool1" tag="gKitPoison"/>
+    <tag group="AllowTool1" tag="gTooPotter"/>
+    <tag group="AllowTool1" tag="gTooSmith"/>
+    <tag group="AllowTool1" tag="gTooTinker"/>
+    <tag group="AllowTool1" tag="Vehicle"/>
+    <tag group="AllowTool1" tag="gVehWater"/>
+    <tag group="AllowTool1" tag="gTooWeaver"/>
+    <tag group="AllowTool1" tag="gTooCarver"/>
+    <tag group="Classes" tag="Artificer" name="Artificer"/>
+    <tag group="CasterType" tag="SpontKnow"/>
+    <tag group="CasterSrc" tag="Arcane"/>
+    <tag group="Helper" tag="3rdCaster"/>
+    <tag group="ArmProfGrp" tag="WepSimple"/>
+    <bootstrap thing="c5CArtToEx">
+      <autotag group="ClSpecWhen" tag="2"/>
+      </bootstrap>
+    <bootstrap thing="gTooThieve">
+      <autotag group="Proficienc" tag="Tool"/>
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtMiAn">
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtWoIn">
+      <autotag group="ClSpecWhen" tag="2"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtWoIn">
+      <autotag group="ClSpecWhen" tag="5"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtWoIn">
+      <autotag group="ClSpecWhen" tag="10"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtWoIn">
+      <autotag group="ClSpecWhen" tag="15"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtWoIn">
+      <autotag group="ClSpecWhen" tag="20"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtInMa">
+      <autotag group="ClSpecWhen" tag="4"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtSuAt">
+      <autotag group="ClSpecWhen" tag="5"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtSuAt">
+      <autotag group="ClSpecWhen" tag="15"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtMeSe">
+      <autotag group="ClSpecWhen" tag="6"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtSoul">
+      <autotag group="ClSpecWhen" tag="20"/>
+      </bootstrap>
+    <link linkage="castattr" thing="aINT"/>
+    <eval phase="Final" priority="21000" index="2"><![CDATA[
+~ I'm doing this because I do not want to edit/duplicate all the spells in the artificer list just to add the sClass.cHelpArt needed for them to show up for the user.
+~ Yes, I'm that lazy.
+
+~ we'll use this to add the spells to our spell list
+var spells as string
+
+spells = " ( thingid.spAlarm | thingid.spCureWoun | thingid.spDisgSelf | thingid.spExpeRetr | thingid.spFalsLife | thingid.sp5CJump | thingid.spLongstri | thingid.spSanctuar | thingid.spShieFait | thingid.spAid | thingid.spAlteSelf | thingid.spArcaLock | thingid.spBlur | thingid.spContFlam | thingid.spDarkvisi | thingid.spEnhaAbil | thingid.sp5cEnlRed | thingid.spInvisibi | thingid.spLessRest | thingid.spLevitate | thingid.spMagiWeap | thingid.spProtPois | thingid.spRopeTric | thingid.spSeeInvi | thingid.spSpidClim | thingid.spBlink | thingid.spFly | thingid.spGaseForm | thingid.spGlypWard | thingid.spHaste | thingid.spProtEner | thingid.spRevivify | thingid.spWateBrea | thingid.spWateWalk | thingid.spArcaEye | thingid.spDeatWard | thingid.spFabricat | thingid.spFreeMove | thingid.spSecrChes | thingid.spFaitHoun | thingid.spPrivSanc | thingid.spResiSphe | thingid.spStonShap | thingid.spStoneski ) "
+field[cSpKnoExpr].text = spells
+field[cSpellExpr].text = spells]]></eval>
+    <eval phase="Level" priority="6000"><![CDATA[
+      ~ Don't reduce our capabilities for multiclassing if this is the first
+      ~ class we have taken.
+      doneif (tagis[Helper.FirstLevel] <> 0)
+
+      ~ Multiclass artificers lose skills, all weapons, and all save proficiencies
+      perform delete[ProfSave.?]
+      perform delete[ArmProfGrp.WepSimple]
+      perform delete[WepProf.?]
+
+      field[cSkillMax].value = 0
+      field[cToolMax].value = 0]]>
+      <before name="Class Helper forwards Proficiency Tags"/>
+      <before name="Weapon and Armor group proficiencies forwarded to hero"/>
+      <after name="Declare First Level"/>
+      </eval>
+    </thing>
+  <thing id="cArtificer" name="Artificer" compset="ClassLevel" maxlimit="20">
+    <usesource source="p5eArtUACP"/>
+    <tag group="ClassType" tag="Normal"/>
+    <bootstrap thing="cHelpArt"></bootstrap>
+    <link linkage="helper" thing="cHelpArt"/>
+    </thing>
+  <thing id="c5CArtMiAn" name="Magic Item Analysis" description="Starting at 1st level, your understanding of magic items allows you to analyze and understand their secrets. You know the artificer spells detect magic and identify, and you can cast them as rituals. You don’t need to provide a material component when casting identify with this class feature." compset="ClSpecial">
+    <bootstrap thing="spDeteMagi">
+      <autotag group="Helper" tag="SpellLike"/>
+      <autotag group="SpellType" tag="cHelpArt"/>
+      </bootstrap>
+    <bootstrap thing="spIdentify">
+      <autotag group="Helper" tag="SpellLike"/>
+      <autotag group="SpellType" tag="cHelpArt"/>
+      </bootstrap>
+    </thing>
+  <thing id="c5CArtToEx" name="Tool Expertise" description="Starting at 2nd level, your proficiency bonus is doubled for any ability check you make that uses any of the tool proficiencies you gain from this class." compset="ClSpecial">
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+~double the prof bonus on the thieve's tools
+perform hero.assign[ProfTooDbl.gTooThieve]
+
+~double the prof bonus on the tools selected
+foreach pick in hero from Tool where "SpecSource.cHelpArt"
+    perform eachpick.pulltags[ProfTooDbl.?]
+nexteach
+perform forward[ProfTooDbl.?]]]>
+      <before name="Calc skProfBon"/>
+      </eval>
+    </thing>
+  <thing id="c5CArtWoIn" name="Wondrous Invention" description="At 2nd level, you gain the use of a magic item that you have crafted. Choose the item from the list of 2nd-level items below.\nCrafting an item is a difficult task. When you gain a magic item from this feature, it reflects long hours of study, tinkering, and experimentation that allowed you to finally complete the item. You are assumed to work on this item in your leisure time and to finish it when you level up.\nYou complete another item of your choice when you reach certain levels in this class: 5th, 10th, 15th, and 20th level. The item you choose must be on the list for your current artificer level or a lower level. \nThese magic items are detailed in the Dungeon Master’s Guide.\n\n{b}NOTE{/b}: To avoid tracking issues, you must manually add the selected item on the Magic tab." compset="ClSpecial">
+    <fieldval field="usrCandid1" value="component.BaseWonder"/>
+    <tag group="ChooseSrc1" tag="Thing"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+~ this ability is granted at several levels. To avoid writing 5 times the same ability, I bootstraped it at the appropriate levels and just check at which level we have been bootstrapped. Notice that this is different from counting levels, because knowing how many levels we have doesn't telme if I have been bootstraped at lvl 2 or 10 . 
+
+~ That also changes the usual logic of nested ifs with increasing bonuses with increasing levels, because the test that checks for the level2 tag will not be true on level 5, and so on.
+
+var itemlst as string
+
+if ( tagis[ClSpecWhen.2] <> 0 ) then
+   itemlst = " thingid.miBagHold | thingid.io5CCapOWa | thingid.io5CDriftg | thingid.miGoggNigh | thingid.ioSendSton "
+endif 
+
+if ( tagis[ClSpecWhen.5] <> 0 ) then
+   itemlst = " thingid.miBagHold | thingid.io5CCapOWa | thingid.io5CDriftg | thingid.miGoggNigh | thingid.ioSendSton | thingid.io5CAlcJug | thingid.miHelmComp | thingid.miLantReve | thingid.riSwimming | thingid.miRobeUsef | thingid.miRopeClim | thingid.waMagiDete | thingid.waSecrets "
+endif 
+
+if ( tagis[ClSpecWhen.10] <> 0 ) then
+   itemlst = " thingid.miBagHold | thingid.io5CCapOWa | thingid.io5CDriftg | thingid.miGoggNigh | thingid.ioSendSton | thingid.io5CAlcJug | thingid.miHelmComp | thingid.miLantReve | thingid.riSwimming | thingid.miRobeUsef | thingid.miRopeClim | thingid.waMagiDete | thingid.waSecrets  | thingid.miBagBean | thingid.miChimOpen | thingid.miDecaEndl | thingid.miEyesMinu | thingid.miFoldBoat | thingid.miHandHave "
+endif 
+
+if ( tagis[ClSpecWhen.15] <> 0 ) then
+   itemlst = " thingid.miBagHold | thingid.io5CCapOWa | thingid.io5CDriftg | thingid.miGoggNigh | thingid.ioSendSton | thingid.io5CAlcJug | thingid.miHelmComp | thingid.miLantReve | thingid.riSwimming | thingid.miRobeUsef | thingid.miRopeClim | thingid.waMagiDete | thingid.waSecrets  | thingid.miBagBean | thingid.miChimOpen | thingid.miDecaEndl | thingid.miEyesMinu | thingid.miFoldBoat | thingid.miHandHave | thingid.miBootStri | thingid.miBracArch | thingid.io5CBroShi | thingid.miBrooFlyi | thingid.miHatDisg | thingid.miSlipSpid "
+endif 
+
+if ( tagis[ClSpecWhen.20] <> 0 ) then
+   itemlst = " thingid.miBagHold | thingid.io5CCapOWa | thingid.io5CDriftg | thingid.miGoggNigh | thingid.ioSendSton | thingid.io5CAlcJug | thingid.miHelmComp | thingid.miLantReve | thingid.riSwimming | thingid.miRobeUsef | thingid.miRopeClim | thingid.waMagiDete | thingid.waSecrets  | thingid.miBagBean | thingid.miChimOpen | thingid.miDecaEndl | thingid.miEyesMinu | thingid.miFoldBoat | thingid.miHandHave | thingid.miBootStri | thingid.miBracArch | thingid.io5CBroShi | thingid.miBrooFlyi | thingid.miHatDisg | thingid.miSlipSpid | thingid.miEyesEagl | thingid.miGemBrig | thingid.miGlovMiss | thingid.miGlovSwim | thingid.riJumping | thingid.riMindShie | thingid.miWingFlyi "
+endif 
+
+
+field[usrCandid1].text = "component.BaseWonder & ( " & itemlst & " ) "
+
+~ debug "EXP: " & field[usrCandid1].text]]></eval>
+    </thing>
+  <thing id="c5CArtInMa" name="Infuse Magic" description="Starting at 4th level, you gain the ability to channel your artificer spells into objects for later use. When you cast an artificer spell with a casting time of 1 action, you can increase its casting time to  1 minute. If you do so and hold a nonmagical item throughout the casting, you expend a spell slot, but none of the spell’s effects occur. Instead, the spell transfers into that item for later use if the item doesn’t already contain a spell from this feature.\nAny creature holding the item thereafter can use an action to activate the spell if the creature has an Intelligence score of at least 6. The spell is cast using your spellcasting ability, targeting the creature that activates the item. If the spell targets more than one creature, the creature that activates the item selects the additional targets. If the spell has an area of effect, it is centered on the item. If the spell’s range is self, it targets the creature that activates the item. \nWhen you infuse a spell in this way, it must be used within 8 hours. After that time, its magic fades and is wasted. \nYou can have a limited number of infused spells at the same time. The number equals your Intelligence modifier." compset="ClSpecial">
+    <tag group="User" tag="Tracker"/>
+    <tag group="Usage" tag="LongRest"/>
+    <tag group="ChargeCalc" tag="AttrOnly"/>
+    <tag group="ChargeAttr" tag="aINT"/>
+    </thing>
+  <thing id="c5CArtSuAt" name="Superior Attunement" description="At 5th level, your superior understanding of magic items allows you to master their use. You can now attune to up to four, rather than three, magic items at a time. \nAt 15th level, this limit increases to five magic items." compset="ClSpecial">
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if ( tagis[ClSpecWhen.5] <> 0 ) then
+   hero.child[Totals].field[tAttunMax].value += 1
+endif
+
+if ( tagis[ClSpecWhen.15] <> 0 ) then
+   hero.child[Totals].field[tAttunMax].value += 1
+endif]]></eval>
+    </thing>
+  <thing id="c5CArtMeSe" name="Mechanical Servant" description="At 6th level, your research and mastery of your craft allow you to produce a mechanical servant. The servant is a construct that obeys your commands without hesitation and functions in combat to protect you. Though magic fuels its creation, the servant is not magical itself. You are assumed to have been working on the servant for quite some time, finally finishing it during a short or long rest after you reach 6th level.\nSelect a Large beast with a challenge rating of 2 or less. The servant uses that beast’s game statistics, but it can look however you like, as long as its form is appropriate for its statistics. It has the following modifications:\n\n•  It is a construct instead of a beast.\n•  It can’t be charmed.\n•  It is immune to poison damage and the poisoned condition.\n•  It gains darkvision with a range of 60 feet if it doesn’t have it already.\n•  It understands the languages you can speak when you create it, but it can’t speak.\n•  If you are the target of a melee attack and the servant is within 5 feet of the attacker, you can use your reaction to command the servant to respond, using its reaction to make a melee attack against the attacker.\n\nThe servant obeys your orders to the best of its ability. In combat, it rolls its own initiative and acts on its own. \n\nIf the servant is killed, it can be returned to life via normal means, such as with the revivify spell. In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest. If the servant is beyond recovery, you can build a new one with one week of work (eight hours each day) and 1,000 gp of raw materials." compset="ClSpecial">
+    <bootstrap thing="c5CArtMech">
+      <containerreq phase="First" priority="455"><![CDATA[count:Classes.Artificer >= 6]]></containerreq>
+      </bootstrap>
+    </thing>
+  <thing id="c5CArtSoul" name="Soul of Artifice" description="At 20th level, your understanding of magic items is unmatched, allowing you to mingle your soul with items linked to you. You can attune to up to six magic items at once. In addition, you gain a +1 bonus to all saving throws per magic item you are currently attuned to." compset="ClSpecial">
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+~ first we update the max attunement
+hero.child[Totals].field[tAttunMax].value += 1]]></eval>
+    <eval phase="PostAttr" priority="10000" index="2"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+~ now, we get the number of attuned items and add to our saves
+var attnum as number
+attnum = hero.child[Totals].field[tAttunCur].value
+hero.child[svAll].field[Bonus].value += attnum]]></eval>
+    </thing>
+  <thing id="c5CArtMech" name="Mechanical Servant" compset="Companion" stacking="never" uniqueness="unique">
+    <fieldval field="CompType" value="MechServ"/>
+    <eval phase="PostAttr" priority="11000"><![CDATA[
+      var searchexpr as string
+      searchexpr = "(hasbootstrap:tpBeast) & RaceSize.Large1 & (fieldval:rCR = 2)"
+      minion.childfound[Totals].field[tRaceExpr].text = searchexpr
+      minion.childfound[Totals].field[tSize].value = 1
+
+      perform minion.childfound[tpBeast].assign[Hide.Special]]]></eval>
+    <minion id="Familiar">
+      <tag group="AllowRCust" tag="Familiar" name="Familiar" abbrev="Familiar"/>
+      <tag group="CompIs" tag="Familiar" name="Familiar" abbrev="Familiar"/>
+      <tag group="Hero" tag="NoAdvance" name="NoAdvance" abbrev="NoAdvance"/>
+      <tag group="Hero" tag="NoFamLvReq" name="No familiar Level requirements" abbrev="No familiar Level requirements"/>
+      <tag group="HideTab" tag="background" name="background" abbrev="background"/>
+      <tag group="HideTab" tag="race" name="race" abbrev="race"/>
+      <tag group="DamageImm" tag="dtPoison"/>
+      <tag group="CondImm" tag="pcnPoison"/>
+      <tag group="CondImm" tag="pcnCharmed"/>
+      <bootstrap thing="raDarkVis">
+        <autotag group="Value" tag="60"/>
+        </bootstrap>
+      </minion>
+    </thing>
+  <thing id="c5CArtAlch" name="Alchemist" description="An alchemist is an expert at combining exotic reagents to produce a variety of materials, from healing draughts that can mend a wound in moments to clinging goo that slows creatures down." compset="CustomSpec" uniqueness="unique">
+    <tag group="SpecSource" tag="cHelpArt"/>
+    <tag group="Helper" tag="Primary"/>
+    <tag group="abCategory" tag="ArtSpecial" name="Artificer Specialist"/>
+    <bootstrap thing="c5CArtSatc">
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtAlFo">
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <eval phase="PostLevel" priority="9000"><![CDATA[       doneif (tagis[Helper.Disable] <> 0)
+
+       linkage[table].field[cSpec3rdNm].text = "Alchemical Formulas"
+       linkage[table].field[cSpec3rdSi].text = "Alchemical Formula"
+
+       linkage[table].field[cCustTeTot].arrayvalue[0] += 1
+       linkage[table].field[cCustTeTot].arrayvalue[2] += 2
+       linkage[table].field[cCustTeTot].arrayvalue[8] += 3
+       linkage[table].field[cCustTeTot].arrayvalue[13] += 4
+       linkage[table].field[cCustTeTot].arrayvalue[16] += 5]]>
+      <before name="Calc cGiveSp3rd"/>
+      </eval>
+    </thing>
+  <thing id="c5CArtGuns" name="Gunsmith" description="A master of engineering, you forge a firearm powered by a combination of science and magic." compset="CustomSpec" uniqueness="unique">
+    <tag group="SpecSource" tag="cHelpArt"/>
+    <tag group="Helper" tag="Primary"/>
+    <tag group="abCategory" tag="ArtSpecial"/>
+    <bootstrap thing="c5CArtMaSm">
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtCann">
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtAMag">
+      <autotag group="ClSpecWhen" tag="1"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtTMon">
+      <autotag group="ClSpecWhen" tag="3"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtBlaW">
+      <autotag group="ClSpecWhen" tag="9"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtPieR">
+      <autotag group="ClSpecWhen" tag="14"/>
+      </bootstrap>
+    <bootstrap thing="c5CArtExpR">
+      <autotag group="ClSpecWhen" tag="17"/>
+      </bootstrap>
+    </thing>
+  <thing id="c5CArtSatc" name="Alchemist’s Satchel" description="At 1st level, you craft an Alchemist’s Satchel, a bag of reagents that you use to create a variety of concoctions. The bag and its contents are both magical, and this magic allows you to pull out exactly the right materials you need for your Alchemical Formula options, described below. After you use one of those options, the bag reclaims the materials.\nIf you lose this satchel, you can create a new one over the course of three days of work  (eight hours each day) by expending 100 gp worth of leather, glass, and other raw materials." compset="ClSpecial">
+    <bootstrap thing="g5CAlchSat"></bootstrap>
+    </thing>
+  <thing id="g5CAlchSat" name="Alchemist’s Satchel" description="This is a bag  of reagents used by Alchemists to create a variety of concotions." compset="Gear" summary="Component Satchel for an Alchemist">
+    <fieldval field="gCost" value="100gp"/>
+    <fieldval field="gWeight" value="0.1"/>
+    <usesource source="p5eArtUACP"/>
+    <tag group="GearType" tag="gtAdventGe"/>
+    </thing>
+  <thing id="c5CArtAlFo" name="Alchemical Formula" description="At 1st level, you learn three Alchemical Formula options: Alchemical Fire, Alchemical Acid, and one other option of your choice. You learn an additional formula of your choice at 3rd, 9th,14th, and 17th levels. \nTo use any of these options, your Alchemist’s Satchel must be within reach.\nIf an Alchemical Formula option requires a saving throw, the DC is 8 + your proficiency bonus + your Intelligence modifier." compset="ClSpecial">
+    <bootstrap thing="c5CArtAlFi"></bootstrap>
+    <bootstrap thing="c5CArtAlAc"></bootstrap>
+    </thing>
+  <thing id="c5CArtAlFi" name="Alchemical Fire" description="As an action, you can reach into your Alchemist’s Satchel, pull out a vial of volatile liquid, and hurl the vial at a creature, object, or surface within 30 feet of you  (the vial and its contents disappear if you don’t hurl the vial by the end of the current turn). On impact, the vial detonates in a 5-foot radius. Any creature in that area must succeed on a Dexterity saving throw or take 1d6 fire damage.\nThis formula’s damage increases by 1d6 when you reach certain levels in this class: 4th level (2d6), 7th level  (3d6), 10th level  (4d6), 13th level (5d6), 16th level  (6d6), and 19th level (7d6)." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abRange" value="30"/>
+    <fieldval field="wDieCount" value="1"/>
+    <fieldval field="wDieSize" value="6"/>
+    <fieldval field="wRangeNorm" value="30"/>
+    <tag group="SpecSource" tag="cHelpArt"/>
+    <tag group="abRange" tag="Feet"/>
+    <tag group="StandardDC" tag="aINT"/>
+    <tag group="wCategory" tag="RangeThrow"/>
+    <tag group="Helper" tag="Tertiary"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula"/>
+    <tag group="DamageType" tag="dtFire"/>
+    <tag group="Helper" tag="WeaponSpec"/>
+    <tag group="Helper" tag="SingleAtt"/>
+    <tag group="Helper" tag="NoAttrDam"/>
+    <tag group="abAction" tag="Action"/>
+    <tag group="CustTaken" tag="cHelpArt"/>
+    <tag group="abSave" tag="aDEX"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if (#levelcount[Artificer] >= 4) then
+   field[wDieCount].value += 1
+   if (#levelcount[Artificer] >= 7) then
+      field[wDieCount].value += 1
+      if (#levelcount[Artificer] >= 10) then
+         field[wDieCount].value += 1
+         if (#levelcount[Artificer] >= 13) then
+            field[wDieCount].value += 1
+            if (#levelcount[Artificer] >= 16) then
+               field[wDieCount].value += 1
+               if (#levelcount[Artificer] >= 19) then
+                  field[wDieCount].value += 1
+               endif
+            endif
+         endif
+      endif
+   endif
+endif]]></eval>
+    </thing>
+  <thing id="c5CArtAlAc" name="Alchemical Acid" description="As an action, you can reach into your Alchemist’s Satchel, pull out a vial of acid, and hurl the vial at a creature, object within 30 feet of you  (the vial and its contents disappear if you don’t hurl the vial by the end of the current turn). The vial shatters on impact.  A creature must succeed on a Dexterity saving throw or take 1d6 acid damage. An object automatically takes that damage, and the damage is maximized.\nThis formula’s damage increases by 1d6 when you reach certain levels in this class: 3th level (2d6), 5th level  (3d6), 7th level  (4d6), 9th level (5d6), 11th level  (6d6),  13th level (7d6),  15th level (8d6), 17th level (9d6), and 19th level (10d6)." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abRange" value="30"/>
+    <fieldval field="wDieCount" value="1"/>
+    <fieldval field="wDieSize" value="6"/>
+    <fieldval field="wRangeNorm" value="30"/>
+    <tag group="Helper" tag="WeaponSpec" name="WeaponSpec" abbrev="WeaponSpec"/>
+    <tag group="SpecSource" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="StandardDC" tag="aINT"/>
+    <tag group="abAction" tag="Action" name="Action" abbrev="Act"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula" abbrev="Alchemist Alchemical Formula"/>
+    <tag group="abRange" tag="Feet" name="Feet" abbrev="ft."/>
+    <tag group="wCategory" tag="RangeThrow" name="Thrown Weapon" abbrev="Thrown"/>
+    <tag group="CustTaken" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="Helper" tag="NoAttrDam" name="NoAttrDam" abbrev="NoAttrDam"/>
+    <tag group="Helper" tag="SingleAtt" name="SingleAtt" abbrev="SingleAtt"/>
+    <tag group="Helper" tag="Tertiary" name="Tertiary" abbrev="Tertiary"/>
+    <tag group="DamageType" tag="dtAcid"/>
+    <tag group="abSave" tag="aDEX"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if (#levelcount[Artificer] >= 4) then
+   field[wDieCount].value += 1
+   if (#levelcount[Artificer] >= 5) then
+      field[wDieCount].value += 1
+      if (#levelcount[Artificer] >= 7) then
+         field[wDieCount].value += 1
+         if (#levelcount[Artificer] >= 9) then
+            field[wDieCount].value += 1
+            if (#levelcount[Artificer] >= 11) then
+               field[wDieCount].value += 1
+               if (#levelcount[Artificer] >= 13) then
+                  field[wDieCount].value += 1
+                  if (#levelcount[Artificer] >= 15) then
+                     field[wDieCount].value += 1
+                     if (#levelcount[Artificer] >= 17) then
+                        field[wDieCount].value += 1
+                        if (#levelcount[Artificer] >= 19) then
+                           field[wDieCount].value += 1
+                        endif
+                     endif
+                  endif
+               endif
+            endif
+         endif
+      endif
+   endif
+endif]]></eval>
+    </thing>
+  <thing id="c5CArtAlHD" name="Healing Draught" description="As an action, you can reach into your Alchemist’s Satchel and pull out a vial of healing liquid. A creature can drink it as an action to regain  1d8 hit points. The vial then disappears. Once a creature regains hit points from this alchemical formula, the creature can’t do so again until it finishes a long rest. If not used, the vial and its contents disappear after 1 hour. While the vial exists, you can’t use this formula.\nThis formula’s healing increases by 1d8 when you reach certain levels in this class: 3rd level (2d8), 5th level (3d8), 7th level (4d8), 9th level (5d8), 11th level (6d8), 13th level (7d8), 15th level (8d8), 17th level (9d8), and 19th level (10d8)." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abDuration" value="1"/>
+    <fieldval field="abValue" value="8"/>
+    <fieldval field="abValue2" value="1"/>
+    <fieldval field="abText" value="hit points"/>
+    <tag group="User" tag="Activation"/>
+    <tag group="Helper" tag="Tertiary" name="Tertiary" abbrev="Tertiary"/>
+    <tag group="abDuration" tag="Hour"/>
+    <tag group="SpecSource" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="abAction" tag="Action" name="Action" abbrev="Act"/>
+    <tag group="LvNamePar" tag="DieCntVal2"/>
+    <tag group="LvNamePar" tag="DieSizVal"/>
+    <tag group="LvNamePar" tag="AppText"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula" abbrev="Alchemist Alchemical Formula"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if (#levelcount[Artificer] >= 4) then
+   field[abValue2].value += 1
+   if (#levelcount[Artificer] >= 5) then
+      field[abValue2].value += 1
+      if (#levelcount[Artificer] >= 7) then
+         field[abValue2].value += 1
+         if (#levelcount[Artificer] >= 9) then
+            field[abValue2].value += 1
+            if (#levelcount[Artificer] >= 11) then
+               field[abValue2].value += 1
+               if (#levelcount[Artificer] >= 13) then
+                  field[abValue2].value += 1
+                  if (#levelcount[Artificer] >= 15) then
+                     field[abValue2].value += 1
+                     if (#levelcount[Artificer] >= 17) then
+                        field[abValue2].value += 1
+                        if (#levelcount[Artificer] >= 19) then
+                           field[abValue2].value += 1
+                        endif
+                     endif
+                  endif
+               endif
+            endif
+         endif
+      endif
+   endif
+endif]]></eval>
+    </thing>
+  <thing id="c5CArtAlSS" name="Smoke Stick" description="As an action, you can reach into your Alchemist’s Satchel and pull out a stick that produces a thick plume of smoke. You can hold on to the stick or throw it to a point up to 30 feet away as part of the action used to produce it. The area in a 10-foot radius around the stick is filled with thick smoke that blocks vision, including darkvision. The stick and smoke persist for 1 minute and then disappear. After using this formula, you can’t do so again for 1 minute." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abDuration" value="1"/>
+    <fieldval field="abRange" value="30"/>
+    <fieldval field="wRangeNorm" value="30"/>
+    <fieldval field="abText" value="10ft radius smoke cloud"/>
+    <tag group="abDuration" tag="Minute"/>
+    <tag group="Helper" tag="Tertiary" name="Tertiary" abbrev="Tertiary"/>
+    <tag group="SpecSource" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="abRange" tag="Feet"/>
+    <tag group="Helper" tag="WeaponSpec"/>
+    <tag group="wCategory" tag="RangeThrow"/>
+    <tag group="abAction" tag="Action" name="Action" abbrev="Act"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula" abbrev="Alchemist Alchemical Formula"/>
+    <tag group="LvNamePar" tag="AppText"/>
+    </thing>
+  <thing id="c5CArtAlSD" name="Swift Step Draught" description="As a bonus action, you can reach into your Alchemist’s Satchel and pull out a vial filled with a bubbling, brown liquid. As an action, a creature can drink it. Doing so increases the creature’s speed by 20 feet for 1 minute, and the vial disappears. If not used, the vial and its contents disappear after 1 minute. After using this formula, you can’t do so again for 1 minute." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abDuration" value="1"/>
+    <fieldval field="wRangeNorm" value="30"/>
+    <fieldval field="abText" value="Adds 20 to speed"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula" abbrev="Alchemist Alchemical Formula"/>
+    <tag group="abDuration" tag="Minute" name="Minute" abbrev="min"/>
+    <tag group="Helper" tag="Tertiary" name="Tertiary" abbrev="Tertiary"/>
+    <tag group="LvNamePar" tag="AppText" name="Append &quot;field[abText].text&quot;" abbrev="Append &quot;field[abText].text&quot;"/>
+    <tag group="SpecSource" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="abAction" tag="Bonus"/>
+    <tag group="abAction" tag="Action"/>
+    <tag group="User" tag="Activation"/>
+    <eval phase="PostLevel" priority="10000">doneif (tagis[Helper.Disable] = 1)
+doneif (field[abilActive].value = 0)
+
+hero.child[Speed].field[tSpeed].value += 20</eval>
+    </thing>
+  <thing id="c5CArtAlTB" name="Tanglefoot Bag" description="As an action, you can reach into your Alchemist’s Satchel and pull out a bag filled with writhing, sticky black tar and hurl it at a point on the ground within 30 feet of you  (the bag and its contents disappear if you don’t hurl the bag by the end of the current turn). The bag bursts on impact and covers the ground in a 5-foot radius with sticky goo. That area becomes difficult terrain for 1 minute, and any creature that starts its turn on the ground in that area has its speed halved for that turn. After using this formula, you can’t do so again for 1 minute." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abRange" value="30"/>
+    <fieldval field="wRangeNorm" value="30"/>
+    <tag group="Helper" tag="Tertiary" name="Tertiary" abbrev="Tertiary"/>
+    <tag group="Helper" tag="WeaponSpec" name="WeaponSpec" abbrev="WeaponSpec"/>
+    <tag group="SpecSource" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="abAction" tag="Action" name="Action" abbrev="Act"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula" abbrev="Alchemist Alchemical Formula"/>
+    <tag group="abRange" tag="Feet" name="Feet" abbrev="ft."/>
+    <tag group="wCategory" tag="RangeThrow" name="Thrown Weapon" abbrev="Thrown"/>
+    <tag group="CustTaken" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="Helper" tag="NoAttrDam" name="NoAttrDam" abbrev="NoAttrDam"/>
+    <tag group="Helper" tag="SingleAtt"/>
+    </thing>
+  <thing id="c5CArtAlTS" name="Thunderstone" description="As an action, you can reach into your Alchemist’s Satchel and pull out a crystalline shard and hurl it at a creature, object, or surface within 30 feet of you  (the shard disappears if you don’t hurl it by the end of the current turn). The shard shatters on impact with a blast of concussive energy. Each creature within 10 feet of the point of impact must succeed on a Constitution saving throw or be knocked prone and pushed 10 feet away from that point." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="abRange" value="30"/>
+    <fieldval field="wRangeNorm" value="30"/>
+    <tag group="Helper" tag="SingleAtt" name="SingleAtt" abbrev="SingleAtt"/>
+    <tag group="Helper" tag="Tertiary" name="Tertiary" abbrev="Tertiary"/>
+    <tag group="Helper" tag="WeaponSpec" name="WeaponSpec" abbrev="WeaponSpec"/>
+    <tag group="SpecSource" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="abAction" tag="Action" name="Action" abbrev="Act"/>
+    <tag group="abCategory" tag="ArtAlcForm" name="Alchemist Alchemical Formula" abbrev="Alchemist Alchemical Formula"/>
+    <tag group="abRange" tag="Feet" name="Feet" abbrev="ft."/>
+    <tag group="wCategory" tag="RangeThrow" name="Thrown Weapon" abbrev="Thrown"/>
+    <tag group="CustTaken" tag="cHelpArt" name="Artificer" abbrev="Artificer"/>
+    <tag group="Helper" tag="NoAttrDam" name="NoAttrDam" abbrev="NoAttrDam"/>
+    <tag group="abSave" tag="aCON"/>
+    <tag group="StandardDC" tag="aINT"/>
+    </thing>
+  <thing id="c5CArtMaSm" name="Master Smith" description="When you choose this specialization at 1st level, you gain proficiency with smith’s tools, and you learn the mending cantrip." compset="ClSpecial">
+    <bootstrap thing="spMending">
+      <autotag group="sClass" tag="cHelpArt"/>
+      <autotag group="SpellType" tag="cHelpArt"/>
+      <autotag group="SpellSort" tag="cHelpArt"/>
+      <autotag group="Helper" tag="Cantrip"/>
+      </bootstrap>
+    <bootstrap thing="gTooSmith">
+      <autotag group="Proficienc" tag="Tool"/>
+      <autotag group="SpecSource" tag="cHelpArt"/>
+      </bootstrap>
+    </thing>
+  <thing id="c5CArtCann" name="Thunder Cannon" description="At 1st level, you forge a deadly firearm using a combination of arcane magic and your knowledge of engineering and metallurgy. This firearm is called a Thunder Cannon. It is a ferocious weapon that fires leaden bullets that can punch through armor with ease.\nYou are proficient with the Thunder Cannon.  The firearm is a two-handed ranged weapon that deals 2d6 piercing damage. Its normal range is 150 feet, and its maximum range if 500 feet. Once fired, it must be reloaded as a bonus action. \nIf you lose your Thunder Cannon, you can create a new one over the course of three days of work  (eight hours each day) by expending 100 gp worth of metal and other raw materials." compset="ClSpecial">
+    <tag group="WepProf" tag="w5CTCannon" name="Thunder Cannon" abbrev="Thunder Cannon"/>
+    <bootstrap thing="w5CTCannon"></bootstrap>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.Disable] <> 0)
+
+perform forward[WepProf.w5CTCannon]]]></eval>
+    </thing>
+  <thing id="w5CTCannon" name="Thunder Cannon" description="This firearm is called a Thunder Cannon. It is a ferocious weapon that fires leaden bullets that can punch through armor with ease.\nYou are proficient with the Thunder Cannon.  The firearm is a two-handed ranged weapon that deals 2d6 piercing damage. Its normal range is 150 feet, and its maximum range if 500 feet. Once fired, it must be reloaded as a bonus action." compset="Weapon">
+    <fieldval field="gSizeCost" value="100"/>
+    <fieldval field="gWeight" value="8"/>
+    <fieldval field="wDieCount" value="2"/>
+    <fieldval field="wDieSize" value="6"/>
+    <fieldval field="wRangeNorm" value="150"/>
+    <fieldval field="wRangeLong" value="500"/>
+    <usesource source="p5eArtUACP"/>
+    <tag group="wProperty" tag="Loading"/>
+    <tag group="wProperty" tag="TwoHanded"/>
+    <tag group="EquipType" tag="Metal"/>
+    <tag group="DamageType" tag="dtPiercing"/>
+    <tag group="Helper" tag="NoSelect"/>
+    <tag group="wProfReq" tag="Special"/>
+    <tag group="wCategory" tag="RangeProj"/>
+    </thing>
+  <thing id="c5CArtAMag" name="Arcane Magazine" description="At 1st level, you craft a leather bag used to carry your tools and ammunition for your Thunder Cannon. Your Arcane Magazine includes the powders, lead shot, and other materials needed to keep that weapon functioning.\nYou can use the Arcane Magazine to produce ammunition for your gun. At the end of each long rest, you can magically produce 40 rounds of ammunition with this magazine. After each short rest, you can produce 10 rounds. \nIf you lose your Arcane Magazine, you can create a new one as part of a long rest, using 25 gp of leather and other raw materials." compset="ClSpecial">
+    <bootstrap thing="g5CArcMaga"></bootstrap>
+    </thing>
+  <thing id="g5CArcMaga" name="Arcane Magazine" description="Your Arcane Magazine includes the powders, lead shot, and other materials needed to keep your Thunder Cannon  functioning.\nYou can use the Arcane Magazine to produce ammunition for your gun. At the end of each long rest, you can magically produce 40 rounds of ammunition with this magazine. After each short rest, you can produce 10 rounds." compset="Gear">
+    <fieldval field="gWeight" value="2"/>
+    <fieldval field="gCost" value="25"/>
+    <fieldval field="gHeldMaxWt" value="40"/>
+    <fieldval field="trkMax" value="40"/>
+    <usesource source="p5eArtUACP"/>
+    <tag group="GearType" tag="gtWeapon"/>
+    <tag group="User" tag="Tracker"/>
+    <tag group="thing" tag="holder" name="Holder" abbrev="???"/>
+    <tag group="Usage" tag="LongRest"/>
+    <tag group="Helper" tag="EquipMag"/>
+    </thing>
+  <thing id="c5CArtTMon" name="Thunder Monger" description="At 3rd level, you learn to channel thunder energy into your Thunder Cannon. As an action, you can make a special attack with your Thunder Cannon that deals an extra  1d6 thunder damage on a hit. This extra damage increases by 1d6 when you reach certain levels in this class: 5th level (2d6), 7th level (3d6), 9th level (4d6), 11th level (5d6), 13th level (6d6), 15th level (7d6), 17th level (8d6), and 19th level (9d6)." compset="ClSpecial">
+    <fieldval field="abValue" value="1"/>
+    <fieldval field="abValue2" value="6"/>
+    <fieldval field="abText" value="thunder"/>
+    <tag group="LvNamePar" tag="AppText"/>
+    <tag group="User" tag="Activation"/>
+    <tag group="LvNamePar" tag="DieCntVal"/>
+    <tag group="LvNamePar" tag="DieSizVal2"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if (#levelcount[Artificer] >= 5) then
+   field[abValue].value += 1
+   if (#levelcount[Artificer] >= 7) then
+      field[abValue].value += 1
+      if (#levelcount[Artificer] >= 9) then
+         field[abValue].value += 1
+         if (#levelcount[Artificer] >= 11) then
+            field[abValue].value += 1
+            if (#levelcount[Artificer] >= 13) then
+               field[abValue].value += 1
+               if (#levelcount[Artificer] >= 15) then
+                  field[abValue].value += 1
+                  if (#levelcount[Artificer] >= 17) then
+                     field[abValue].value += 1
+                     if (#levelcount[Artificer] >= 19) then
+                        field[abValue].value += 1
+                     endif
+                  endif
+               endif
+            endif
+         endif
+      endif
+   endif
+endif
+
+doneif (field[abilActive].value = 0)
+~adds the extra damage to the weapon
+
+hero.childfound[w5CTCannon].field[wDamExtra].text &= " +" & field[abValue].value & "d" & field[abValue2].value & " " & field[abText].text]]></eval>
+    </thing>
+  <thing id="c5CArtBlaW" name="Blast Wave" description="Starting at 9th level, you can channel force energy into your Thunder Cannon. As an action, you can make a special attack with it. Rather than making an attack roll, you unleash force energy in a 15-foot cone from the gun. Each creature in that area must make a Strength saving throw with a DC of 8 + your proficiency bonus + your Intelligence modifier. On a failed saving throw, a target takes 2d6 force damage and is pushed 10 feet away from you.\nThis damage increases by 1d6 when you reach certain levels in this class:  13th level (3d6) and 17th level (4d6)." compset="ClSpecial">
+    <fieldval field="abRange" value="15"/>
+    <fieldval field="abText" value="force, plus 10ft push"/>
+    <fieldval field="abValue" value="2"/>
+    <fieldval field="abValue2" value="6"/>
+    <tag group="StandardDC" tag="aINT"/>
+    <tag group="abRange" tag="Feet"/>
+    <tag group="abAction" tag="Action"/>
+    <tag group="abSave" tag="aSTR"/>
+    <tag group="LvNamePar" tag="AppText"/>
+    <tag group="LvNamePar" tag="DieCntVal"/>
+    <tag group="LvNamePar" tag="DieSizVal2"/>
+    <bootstrap thing="c5CArtBla2"></bootstrap>
+    </thing>
+  <thing id="c5CArtBla2" name="Blast Wave" description="Starting at 9th level, you can channel force energy into your Thunder Cannon. As an action, you can make a special attack with it. Rather than making an attack roll, you unleash force energy in a 15-foot cone from the gun. Each creature in that area must make a Strength saving throw with a DC of 8 + your proficiency bonus + your Intelligence modifier. On a failed saving throw, a target takes 2d6 force damage and is pushed 10 feet away from you.\nThis damage increases by 1d6 when you reach certain levels in this class:  13th level (3d6) and 17th level (4d6)." compset="CustomSpec" uniqueness="unique">
+    <fieldval field="wDieCount" value="2"/>
+    <fieldval field="wDieSize" value="6"/>
+    <fieldval field="wRangeNorm" value="15"/>
+    <fieldval field="abText" value="plus 10ft push"/>
+    <fieldval field="wDamExtra" value=" plus 10ft push"/>
+    <tag group="SpecSource" tag="cHelpArt"/>
+    <tag group="Helper" tag="SpecUp"/>
+    <tag group="Helper" tag="NoAttrDam"/>
+    <tag group="DamageType" tag="dtForce"/>
+    <tag group="Helper" tag="Quintenary"/>
+    <tag group="Helper" tag="WeaponSpec"/>
+    <tag group="Helper" tag="SingleAtt"/>
+    <tag group="abSave" tag="aSTR"/>
+    <tag group="StandardDC" tag="aINT"/>
+    <tag group="wCategory" tag="RangeProj"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if (#levelcount[Artificer] >= 13) then
+   field[wDieCount].value += 1
+   if (#levelcount[Artificer] >= 17) then
+      field[wDieCount].value += 1
+   endif
+endif]]></eval>
+    </thing>
+  <thing id="c5CArtPieR" name="Piercing Round" description="Starting at 14th level, you can shoot lightning energy through your Thunder Cannon. As an action, you can make a special attack with it. Rather than making an attack roll, you cause the gun to unleash a bolt of lightning, 5-feet wide and 30-feet long. Each creature in that area must make Dexterity saving throws with a DC of 8 + your proficiency bonus + your Intelligence modifier. On a failed saving throw, a target takes 4d6 lightning damage. This damage increases to 6d6 when you reach  19th level in this class." compset="ClSpecial">
+    <fieldval field="abRange" value="30"/>
+    <fieldval field="abValue" value="4"/>
+    <fieldval field="abValue2" value="6"/>
+    <fieldval field="abText" value="lightning"/>
+    <tag group="StandardDC" tag="aINT"/>
+    <tag group="abRange" tag="Feet"/>
+    <tag group="abAction" tag="Action"/>
+    <tag group="abSave" tag="aDEX"/>
+    <tag group="LvNamePar" tag="DieCntVal"/>
+    <tag group="LvNamePar" tag="AppText"/>
+    <tag group="LvNamePar" tag="DieSizVal2"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if (#levelcount[Artificer] >= 19) then
+   field[abValue].value += 2
+endif]]></eval>
+    </thing>
+  <thing id="c5CArtExpR" name="Explosive Round" description="Starting at 17th level, you can channel fiery energy into your Thunder Cannon. As an action, you can make a special attack with it. Rather than making an attack roll, you launch an explosive round from the gun. The round detonates in a 30-foot radius sphere at a point within range. Each creature in that area must make a Dexterity saving throw with a DC of 8 + your proficiency bonus + your Intelligence modifier. On a failed saving throw, a target takes 4d8 fire damage." compset="ClSpecial">
+    <fieldval field="abRange" value="500"/>
+    <fieldval field="abValue" value="4"/>
+    <fieldval field="abValue2" value="8"/>
+    <fieldval field="abText" value="fire"/>
+    <tag group="StandardDC" tag="aINT"/>
+    <tag group="abAction" tag="Action"/>
+    <tag group="abRange" tag="Feet"/>
+    <tag group="abSave" tag="aDEX"/>
+    <tag group="LvNamePar" tag="DieCntVal"/>
+    <tag group="LvNamePar" tag="AppText"/>
+    <tag group="LvNamePar" tag="DieSizVal2"/>
+    </thing>
+  </document>


### PR DESCRIPTION
Implements the new Artificer class described in http://dnd.wizards.com/articles/unearthed-arcana/artificer 

Notes:
The Mechanical Servant is not turned into a Construct due to a validation error, since the Racial tag expression demands the eligible creatures to be Beasts.
The Mechanical Servant does not gain it's master languages, since I could not check which ones he gained after the level 6, as said by the article.
The Artificer Spell List was implemented using an ugly rack on the tag expressions govering the available spells. This was done because I did not want to duplicate every single spell in the list just to add the sClass.cHelpArt tag to them. This might bite me in the future...