### PR TITLE
Implements Temporary hitpoints pools

### DIFF
--- a/COM_5ePack_PHB - Feats.user
+++ b/COM_5ePack_PHB - Feats.user
@@ -215,6 +215,19 @@
   <thing id="ft5CInspiL" name="Inspiring Leader" description="You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. \n\nWhen you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand  you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can’t gain temporary hit points from this feat again until it has finished a short or long rest.\n\nPrerequisite: Charisma 13 or higher" compset="Feat" summary="You can spend 10 minutes inspiring your companions, shoring up their resolve to fight." uniqueness="useronce">
     <usesource source="5ePHBCP"/>
     <tag group="Helper" tag="ShowSpec"/>
+    <bootstrap thing="PoolWlkBls">
+      <autotag group="Value" tag="2"/>
+      <assignval field="livename" value="Inspiring Leader"/>
+      </bootstrap>
+    <eval phase="Final" priority="500" name="Calculate dark one&apos;s blessing temp Hp"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+field[abValue].value += #totallevelcount[] + #attrmod[aCHA]
+
+var temphp as number
+temphp = maximum(field[abValue].value,1)
+hero.findchild[TempHpPool,"Value.2"].field[thpMinAllw].value = temphp
+hero.findchild[TempHpPool,"Value.2"].field[thpMaxAllw].value = temphp]]></eval>
     <exprreq message="Charisma 13 or higher. "><![CDATA[#attrvalue[aCHA] >= 13]]></exprreq>
     </thing>
   <thing id="ft5CKeenMi" name="Keen Mind" description="Increase your Intelligence score by 1, to a maximum of 20.\n• You always know which way is north.\n• You always know the number of hours left before the next sunrise or sunset.\n• You can accurately recall anything you have seen or heard within the past month." compset="Feat" uniqueness="useronce">

--- a/COM_5ePack_SCAG - Classes.user
+++ b/COM_5ePack_SCAG - Classes.user
@@ -280,6 +280,16 @@ doneif (#levelcount[Wizard] < 14)
   <thing id="c5CBbnReAb" name="Reckless Abandon" description="You gain your Constitution modifier (minimum 1) temporary hitpoints when you use Reckless Attack while raging, which vanish if any are left when your rage ends." compset="ClSpecial">
     <tag group="abAction" tag="None"/>
     <tag group="abRange" tag="Personal"/>
+    <bootstrap thing="PoolWlkBls">
+      <autotag group="Value" tag="3"/>
+      <assignval field="livename" value="Reckless Abandon"/>
+      </bootstrap>
+    <eval phase="Render" priority="10000" index="2"><![CDATA[
+      if (field[xIndex].value >= 2) then
+        field[listname].text = field[thingname].text & " (" & field[xIndex].value & " dice)"
+      else
+        field[listname].text = field[thingname].text & " (" & field[xIndex].value & " die)"
+        endif]]></eval>
     <eval phase="PostLevel" priority="10000"><![CDATA[
 
       ~These calculations should only happen for the first copy
@@ -294,12 +304,16 @@ doneif (#levelcount[Wizard] < 14)
         perform assign[LvNamePar.AppValue]
         perform assign[LvNamePar.AppText]
         endif]]></eval>
-    <eval phase="Render" priority="10000" index="2"><![CDATA[
-      if (field[xIndex].value >= 2) then
-        field[listname].text = field[thingname].text & " (" & field[xIndex].value & " dice)"
-      else
-        field[listname].text = field[thingname].text & " (" & field[xIndex].value & " die)"
-        endif]]></eval>
+    <eval phase="Final" priority="500" index="3" name="Calculate dark one&amp;apos;s blessing temp Hp"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+field[abValue].value = #attrmod[aCON]
+
+var temphp as number
+temphp = maximum(field[abValue].value,1)
+
+hero.findchild[TempHpPool,"Value.3"].field[thpMinAllw].value = temphp
+hero.findchild[TempHpPool,"Value.3"].field[thpMaxAllw].value = temphp]]></eval>
     </thing>
   <thing id="c5CBbnBaCh" name="Battlerager Charge" description="While raging you can take the Dash action as a bonus action." compset="ClSpecial" summary="You can take the Dash action as a bonus action while you are raging.">
     <tag group="abRange" tag="Personal"/>
@@ -1241,6 +1255,20 @@ doneif (tagis[Helper.Disable] <> 0)
     <tag group="abRange" tag="Feet"/>
     <tag group="abAction" tag="None"/>
     <tag group="abDuration" tag="Instant"/>
+    <bootstrap thing="PoolWlkBls">
+      <autotag group="Value" tag="4"/>
+      <assignval field="livename" value="Touch of Death"/>
+      </bootstrap>
+    <eval phase="Final" priority="500" name="Calculate dark one&amp;apos;s blessing temp Hp"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+field[abValue].value = #totallevelcount[] + #attrmod[aWIS]
+
+var temphp as number
+temphp = maximum(field[abValue].value,1)
+
+hero.findchild[TempHpPool,"Value.4"].field[thpMinAllw].value = temphp
+hero.findchild[TempHpPool,"Value.4"].field[thpMaxAllw].value = temphp]]></eval>
     </thing>
   <thing id="c5CHourRea" name="Hour of Reaping" description="At 6th level, when you take this action, each creature within 30 feet of you that can see you must succeed on a Wisdom saving throw or be frightened of you until the end of your next turn." compset="ClSpecial">
     <fieldval field="abRange" value="30"/>

--- a/COM_5ePack_UA - Faith Classes.user
+++ b/COM_5ePack_UA - Faith Classes.user
@@ -449,7 +449,7 @@ if (#levelcount[Wizard] >= 11) then
    foreach pick in hero from BaseSpell where spelltag
            spelltot += 1
    nexteach
-   ~debug "Spell total: " & spelltot
+   debug "Spell total: " & spelltot
    ~ we want all(10) spells to allow other cleric spells
    if (spelltot = 10) then
       spelltag &= " | ( sClass.cHelpClr & !(sLevel.0)) "

--- a/COM_5ePack_UA - Ranger_Rogue.user
+++ b/COM_5ePack_UA - Ranger_Rogue.user
@@ -243,6 +243,10 @@ nexteach]]></eval>
     <tag group="abRange" tag="Personal"/>
     <tag group="User" tag="Activation"/>
     <tag group="abAction" tag="Bonus"/>
+    <bootstrap thing="PoolWlkBls">
+      <autotag group="Value" tag="5"/>
+      <assignval field="livename" value="Guardian Soul"/>
+      </bootstrap>
     <eval phase="PostLevel" priority="15000"><![CDATA[doneif (tagis[Helper.Disable] = 1)
 doneif (field[abilActive].value = 0)
 
@@ -278,6 +282,20 @@ if (hero.tagcount[Classes.5CRgC] >= 7) then
    extraHP = extraHP * 2
    hero.child[Totals].field[tBonusHP].value += extraHP
 endif]]></eval>
+    <eval phase="Final" priority="500" index="2" name="Calculate dark one&apos;s blessing temp Hp"><![CDATA[doneif (tagis[Helper.ShowSpec] = 0)
+doneif (tagis[Helper.Disable] <> 0)
+
+if ( hero.tagis[Classes.Ranger] <> 0 ) then
+   field[abValue].value = round(#levelcount[Ranger] / 2,0,0)
+else
+   field[abValue].value = round(hero.tagcount[Classes.5CRgC] / 2,0,0)
+endif
+
+var temphp as number
+temphp = maximum(field[abValue].value,1)
+
+hero.findchild[TempHpPool,"Value.5"].field[thpMinAllw].value = temphp
+hero.findchild[TempHpPool,"Value.5"].field[thpMaxAllw].value = temphp]]></eval>
     </thing>
   <thing id="c5CRgrPieT" name="Piercing Thorns" description="At 3rd level, your command of primal magic allows you to enhance your attacks with thorns. Once during each of your turns, you can deal an additional 1d6 piercing damage to one creature you hit with a weapon attack." compset="ClSpecial">
     <fieldval field="abValue" value="1"/>


### PR DESCRIPTION
Implements temporary hit point pools for:
- Inspiring Leader Feat
- reckless abandon (SCAG, Battlerager barbarian, lvl 6th)
- touch of death (SCAG, Long Death Monk, lvl 3rd)
- guardian soul(UA Ranger & Rogue, Ranger Primeval Guardian)