### PR TITLE
Updated XGTE Spells to fix the indicator for AL

### DIFF
--- a/COM_5ePack_XGTE - Spells.user
+++ b/COM_5ePack_XGTE - Spells.user
@@ -12,7 +12,7 @@
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
     <tag group="sDuration" tag="Instant"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -23,7 +23,7 @@
     <usesource source="5eXGTECP" parent="UserParent"/>
     <tag group="sSchool" tag="Abjur"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -44,7 +44,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -59,7 +59,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -74,7 +74,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     </thing>
   <thing id="sp5CXGECat" name="Catapult" description="Choose one object weighing 1 to 5 pounds within range that isn’t being worn or carried. The object flies in a straight line up to 90 feet in a direction you choose before falling to the ground, stopping early if it impacts against a solid surface. If the object would strike a creature, that creature must make a Dexterity saving throw. On a failed save, the object strikes the target and stops moving. When the object strikes something, the object and what it strikes each take 3d8 bludgeoning damage. \n\n{b}At Higher Levels.{/b} When you cast this spell using a spell slot of 2nd level or higher, the maximum weight of objects that you can target with this spell increases by 5 pounds, and the damage increases by 1d8, for each slot level above 1st.           " compset="Spell">
@@ -85,7 +85,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -99,7 +99,7 @@
     <tag group="sSchool" tag="Enchant"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -112,7 +112,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Necromancy"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -128,7 +128,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     <tag group="sClass" tag="cHelpPal"/>
     </thing>
@@ -141,7 +141,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     </thing>
   <thing id="sp5CXGEChM" name="Charm Monster" description="Target a creature you can see within range. It must make a Wisdom saving throw, and it does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it. The charmed creature is friendly to you. When the spell ends, the creature knows it was charmed by you. \n\n{b}At Higher Levels.{/b} When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them." compset="Spell">
@@ -153,7 +153,7 @@
     <tag group="sSchool" tag="Enchant"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
@@ -168,7 +168,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -182,7 +182,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -196,7 +196,7 @@
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -211,7 +211,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     <tag group="sCastTime" tag="Hour1"/>
     <tag group="sLevel" tag="6"/>
@@ -225,7 +225,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -239,7 +239,7 @@
     <tag group="sSchool" tag="Necromancy"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -254,7 +254,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -269,7 +269,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -283,7 +283,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sLevel" tag="6"/>
     </thing>
@@ -298,7 +298,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -311,7 +311,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -326,7 +326,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
@@ -341,7 +341,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -355,7 +355,7 @@
     <tag group="sSchool" tag="Enchant"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -370,7 +370,7 @@
     <tag group="sSchool" tag="Necromancy"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -386,7 +386,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -399,7 +399,7 @@
     <tag group="sCastTime" tag="BonusAct1"/>
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -413,7 +413,7 @@
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpPal"/>
     </thing>
   <thing id="sp5CXGEFlA" name="Flame Arrows" description="When a target is hit by a ranged weapon attack using a piece of ammunition drawn from the quiver, the target takes an extra 1d6 fire damage. The spell’s magic ends on a piece of ammunition when it hits or misses, and the spell ends when twelve pieces of ammunition have been drawn from the quiver. \n\n{b}At Higher Levels.{/b} When you cast this spell using a spell slot of 4th level or higher, the number of pieces of ammunition you can affect with this spell increases by two for each slot level above 3rd." compset="Spell">
@@ -425,7 +425,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -442,7 +442,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -456,7 +456,7 @@
     <tag group="sCastTime" tag="BonusAct1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -471,7 +471,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -485,7 +485,7 @@
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -500,7 +500,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     <tag group="sClass" tag="cHelpPal"/>
     </thing>
@@ -514,7 +514,7 @@
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -527,7 +527,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Illusion"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
   <thing id="sp5CXGEImm" name="Immolation" description="One creature you see within range must make a Dexterity saving throw. It takes 8d6 fire damage on a failed save, or half as much damage on a successful one. On a failed save, the target also burns for the spell’s duration. The burning target sheds bright light in a 30-foot radius and dim light for an additional 30 feet. At the end of each of its turns, the target repeats the saving throw. It takes 4d6 fire damage on a failed save, and the spell ends on a successful one. These magical flames can’t be extinguished by nonmagical means. \n\nIf damage from this spell kills a target, the target is turned to ash." compset="Spell">
@@ -538,7 +538,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -553,7 +553,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -568,7 +568,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -583,7 +583,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -598,7 +598,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -613,7 +613,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -628,7 +628,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -643,7 +643,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     <tag group="sLevel" tag="9"/>
     </thing>
@@ -656,7 +656,7 @@
     <tag group="sSchool" tag="Necromancy"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -670,7 +670,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -685,7 +685,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     </thing>
   <thing id="sp5CXGEMaS" name="Magic Stone" description="You touch one to three pebbles and imbue them with magic. You or someone else can make a ranged spell attack with one of the pebbles by throwing it or hurling it with a sling. If thrown, a pebble has a range of 60 feet. If someone else attacks with a pebble, that attacker adds your spellcasting ability modifier, not the attacker’s, to the attack roll. On a hit, the target takes bludgeoning damage equal to 1d6 + your spellcasting ability modifier. Whether the attack hits or misses, the spell then ends on the stone. \n\nIf you cast this spell again, the spell ends on any pebbles still affected by your previous casting." compset="Spell">
@@ -697,7 +697,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpWlk"/>
     </thing>
@@ -712,7 +712,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -728,7 +728,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -743,7 +743,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -755,7 +755,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Illusion"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -771,7 +771,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
   <thing id="sp5CXGEMiS" name="Mind Spike" description="One creature within range must make a Wisdom saving throw, taking 3d8 psychic damage on a failed save, or half as much damage on a successful one. On a failed save, you also always know the target’s location until the spell ends, but only while the two of you are on the same plane of existence. While you have this knowledge, the target can’t become hidden from you, and if it’s invisible, it gains no benefit from that condition against you. \n\n{b}At Higher Levels.{/b} When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd." compset="Spell">
@@ -782,7 +782,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Divination"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -795,7 +795,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -811,7 +811,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -823,7 +823,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Enchant"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -836,7 +836,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     </thing>
   <thing id="sp5CXGEPrW" name="Primordial Ward" description="You have resistance to acid, cold, fire, lightning, and thunder damage for the spell’s duration. \n\nWhen you take damage of one of those types, you can use your reaction to gain immunity to that type of damage, including against the triggering damage. If you do so, the resistances end, and you have the immunity until the end of your next turn, at which time the spell ends." compset="Spell">
@@ -848,7 +848,7 @@
     <tag group="sSchool" tag="Abjur"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     </thing>
   <thing id="sp5CXGEPsS" name="Psychic Scream" description="Target up to ten creatures of your choice that you can see within range. Creatures that have an Intelligence score of 2 or lower are unaffected. \n\nEach target must make an Intelligence saving throw. On a failed save, a target takes 14d6 psychic damage and is stunned. On a successful save, a target takes half as much damage and isn’t stunned. If a target is killed by this damage, its head explodes, assuming it has one. \n\nA stunned target can make an Intelligence saving throw at the end of each of its turns. On a successful save, the stunning effect ends." compset="Spell">
@@ -859,7 +859,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Enchant"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -874,7 +874,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -887,7 +887,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -901,7 +901,7 @@
     <tag group="sSchool" tag="Illusion"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -917,7 +917,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     </thing>
   <thing id="sp5CXGEShW" name="Shape Water" description="You choose an area of water that you can see within range and that fits within a 5-foot cube. You manipulate it in one of the following ways: \n\n- You instantaneously move or otherwise change the flow of the water as you direct, up to 5 feet in any direction. This movement doesn’t have enough force to cause damage. \n- You cause the water to form into simple shapes and animate at your direction. This change lasts for 1 hour. \n- You change the water’s color or opacity. The water must be changed in the same way throughout. This change lasts for 1 hour. \n- You freeze the water, provided that there are no creatures in it. The water unfreezes in 1 hour. \n\nIf you cast this spell multiple times, you can have no more than two of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action." compset="Spell">
@@ -928,7 +928,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -942,7 +942,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -956,7 +956,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -971,7 +971,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -986,7 +986,7 @@
     <tag group="sSchool" tag="Abjur"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -1004,7 +1004,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -1012,7 +1012,7 @@
     <fieldval field="sCompDesc" value="a tiny silver cage worth 100 gp"/>
     <fieldval field="sDuration" value="8 Hours"/>
     <usesource source="5eXGTECP" parent="UserParent"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     <tag group="sSchool" tag="Necromancy"/>
@@ -1031,7 +1031,7 @@
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
     <tag group="sClass" tag="cHelpSRg"/>
@@ -1046,7 +1046,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -1061,7 +1061,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -1076,7 +1076,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -1089,7 +1089,7 @@
     <tag group="sSchool" tag="Enchant"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
@@ -1106,7 +1106,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     </thing>
   <thing id="sp5CXGETeT" name="Transformation" description="Until the spell ends, you can’t cast spells, and you gain the following benefits: \n\n- You gain 50 temporary hit points. If any of these remain when the spell ends, they are lost. \n- You have advantage on attack rolls that you make with simple and martial weapons. \n- When you hit a target with a weapon attack, that target takes an extra 2d12 force damage. \n- You have proficiency with all armor, shields, simple weapons, and martial weapons. \n- You have proficiency in Strength and Constitution saving throws. \n- You can attack twice, instead of once, when you take the Attack action on your turn. You ignore this benefit if you already have a feature, like Extra Attack, that gives you extra attacks. \n\nImmediately after the spell ends, you must succeed on a DC 15 Constitution saving throw or suffer one level of exhaustion." compset="Spell">
@@ -1120,7 +1120,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
   <thing id="sp5CXGEThu" name="Thunderclap" description="You create a sound that can be heard up to 100 feet away. Each creature within range, other than you, must succeed on a Constitution saving throw or take 1d6 thunder damage. \n\nThe spell’s damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)." compset="Spell">
@@ -1131,7 +1131,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
@@ -1146,7 +1146,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Conjur"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1162,7 +1162,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1176,7 +1176,7 @@
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
   <thing id="sp5CXGETot" name="Toll the Dead" description="Choose one creature you can see within range. The target must succeed on a Wisdom saving throw or take 1d8 necrotic damage. If the target is missing any of its hit points, it instead takes 1d12 necrotic damage. \n\nThe spell’s damage increases by one die when you reach 5th level (2d8 or 2d12), 11th level (3d8 or 3d12), and 17th level (4d8 or 4d12)." compset="Spell">
@@ -1188,7 +1188,7 @@
     <tag group="sSchool" tag="Necromancy"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1204,7 +1204,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -1219,7 +1219,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
@@ -1234,7 +1234,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWlk"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1250,7 +1250,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpWiz"/>
     </thing>
   <thing id="sp5CXGEWaW" name="Wall of Water" description="You can make the wall at a point on the ground you can see within range up to 30 feet long, 10 feet high, and 1 foot thick, or you can make a ringed wall up to 20 feet in diameter, 20 feet high, and 1 foot thick. The wall vanishes when the spell ends. The wall’s space is difficult terrain. \n\nAny ranged weapon attack that enters the wall’s space has disadvantage on the attack roll, and fire damage is halved if the fire effect passes through the wall to reach its target. Spells that deal cold damage that pass through the wall cause the area of the wall they pass through to freeze solid (at least a 5-foot-square section is frozen). Each 5-foot-square frozen section has AC 5 and 15 hit points. Reducing a frozen section to 0 hit points destroys it. When a section is destroyed, the wall’s water doesn’t fill it." compset="Spell">
@@ -1264,7 +1264,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1277,7 +1277,7 @@
     <tag group="sCastTime" tag="Action1"/>
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpBrd"/>
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
@@ -1294,7 +1294,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1310,7 +1310,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpSor"/>
     <tag group="sClass" tag="cHelpWiz"/>
@@ -1326,7 +1326,7 @@
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
     <tag group="sComp" tag="M"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpClr"/>
     </thing>
   <thing id="sp5CXGEWro" name="Wrath of Nature" description="Choose a point you can see within range. Trees, rocks, and grasses in a 60-foot cube centered on that point to become animated until the spell ends. \n\n{b}Grasses and Undergrowth.{/b} Any area of ground in the cube that is covered by grass or undergrowth is difficult terrain for your enemies. \n\n{b}Trees.{/b} At the start of each of your turns, each of your enemies within 10 feet of any tree in the cube must succeed on a Dexterity saving throw or take 4d6 slashing damage from whipping branches. \n\n{b}Roots and Vines.{/b} At the end of each of your turns, one creature of your choice that is on the ground in the cube must succeed on a Strength saving throw or become restrained until the spell ends. A restrained creature can use an action to make a Strength (Athletics) check against your spell save DC, ending the effect on itself on a success. \n\n{b}Rocks.{/b} As a bonus action on your turn, you can cause a loose rock in the cube to launch at a creature you can see in the cube. Make a ranged spell attack against the target. On a hit, the target takes 3d8 nonmagical bludgeoning damage, and it must succeed on a Strength saving throw or fall prone." compset="Spell">
@@ -1338,7 +1338,7 @@
     <tag group="sSchool" tag="Evocation"/>
     <tag group="sComp" tag="V"/>
     <tag group="sComp" tag="S"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpDrd"/>
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
@@ -1352,9 +1352,10 @@
     <tag group="sCastTime" tag="BonusAct1"/>
     <tag group="sSchool" tag="Transmutat"/>
     <tag group="sComp" tag="V"/>
-    <tag group="Helper" tag="NoAdvLeag"/>
+
     <tag group="sClass" tag="cHelpRgr"/>
     <tag group="sClass" tag="cHelpRgC"/>
     <tag group="sClass" tag="cHelpSRg"/>
     </thing>
   </document>
+


### PR DESCRIPTION
All XGTE spells were marked as not legal for AL use. I pulled the code into excel, searched and replaced with blanks all 95 instances of that indicator. No issues popped up when the updated file was compiled on next HL open.