### PR TITLE
Added Backgrounds and Dark Gifts for VRGTR

### DIFF
--- a/COM_5ePack_VRGTR - Backgrounds.user
+++ b/COM_5ePack_VRGTR - Backgrounds.user
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document signature="Hero Lab Data">
+  <thing id="bck5CVRGRHaunt" name="Haunted One" description="You are haunted by something so terrible that you dare not speak of it. Whatever this thing is that haunts you can&apos;t be slain with a sword or banished with a spell. It might come to you as a shadow on the wall, a bloodcurdling nightmare, a memory that refuses to die, or a demonic whisper in the dark. You must fnd a way to overcome it befre it destroys you." compset="Background" uniqueness="unique">
+    <comment>yes, this is a kind of a duplicate from CoS. The harrowing events are the same, but it gets an entire new set of horror personality traits, bonds, ideals, and flaws</comment>
+    <fieldval field="StartLang" value="2"/>
+    <fieldval field="AbilName" value="Harrowing Event"/>
+    <fieldval field="AbilPlur" value="Harrowing Event"/>
+    <fieldval field="AbilMax" value="1"/>
+    <fieldval field="cSkillMax" value="2"/>
+    <fieldval field="StartAll" value="•  Monster hunter&apos;s pack{br}•  One trinket of special signifcance {br}•  One Holy Symbol{br}•  Common clothes{br}•  1 sp"/>
+    <fieldval field="StartGear" value="•  Monster hunter&apos;s pack{br}•  One trinket of special signifcance {br}•  One Holy Symbol{br}•  Common clothes{br}•  1 sp"/>
+    <usesource source="5eVRGtR"/>
+    <tag group="AllowSkl1" tag="skSurvival" name="Survival" abbrev="Survival"/>
+    <tag group="AllowSkl1" tag="skInvestig" name="Investigation" abbrev="Investigation"/>
+    <tag group="AllowSkl1" tag="skReligion" name="Religion" abbrev="Religion"/>
+    <tag group="AllowSkl1" tag="skArcana" name="Arcana" abbrev="Arcana"/>
+    <bootstrap thing="ab5CVRGRHoD"></bootstrap>
+    </thing>
+  <thing id="bck5CVRGRInvst" name="Investigator" description="You relentlessly seek the truth. Perhaps you&apos;re motivated by belief in the law and a sense of universal justice, or maybe that very law has failed you and you seek to make things right. You could have witnessed something remarkable or terrible, and now you must know more about this hidden truth. Or maybe you&apos;re a detective for hire, uncovering secrets for well-paying clients. You&apos;re driven by a personal need to hunt down even the most elusive clues and reveal what others would keep hidden in the shadows." compset="Background" uniqueness="unique">
+    <fieldval field="AbilPlur" value="First Case"/>
+    <fieldval field="AbilMax" value="1"/>
+    <fieldval field="cSkillMax" value="2"/>
+    <fieldval field="StartAll" value="•  Magnifying glass{br}•  Evidence from a past case{br}•  Common clothes{br}•  10 gp"/>
+    <fieldval field="StartGear" value="•  Magnifying glass{br}•  Evidence from a past case{br}•  Common clothes{br}•  10 gp"/>
+    <fieldval field="AbilName" value="First Case"/>
+    <usesource source="5eVRGtR"/>
+    <tag group="AllowSkl1" tag="skInsight"/>
+    <tag group="AllowSkl1" tag="skPercep"/>
+    <tag group="AllowSkl1" tag="skInvestig" name="Investigation" abbrev="Investigation"/>
+    <bootstrap thing="ab5COffInq"></bootstrap>
+    </thing>
+  <thing id="ab5COffInq" name="Official Inquiry" description="Through a combination of fast-talking, determination, and official-looking documentation, you can gain access to a place or an individual related to a crime you&apos;re investigating. Those not involved in your investigation avoid impeding you or pass along your requests. Law enforcement sees you as either a nuisance or one of their own." compset="Ability">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <tag group="ProductId" tag="Wizards" name="Wizards of the Coast, LLC" abbrev="Wizards of the Coast, LLC"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="bt5CHrBnd1" name="Return" description="I lost someone or someplace and need to get back to them." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="1"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Background" tag="bckHaunted"/>
+    </thing>
+  <thing id="bt5CHrBnd2" name="Master" description="I serve someone powerful, but no one can know." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="2"/>
+    </thing>
+  <thing id="bt5CHrBnd3" name="Mentor" description="I carry on their work and strive to find them." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="3"/>
+    </thing>
+  <thing id="bt5CHrBnd4" name="Light" description="I must be the brightest of lights in a battle against the dark." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="4"/>
+    </thing>
+  <thing id="bt5CHrBnd5" name="Redeemer" description="I must save someone I love from what they&apos;ve become." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="5"/>
+    </thing>
+  <thing id="bt5CHrBnd6" name="Truth" description="I must prove false a terrible lie to the world." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="6"/>
+    </thing>
+  <thing id="bt5CHrFlw1" name="Harbinger" description="I bring nothing but misfortune for those around me." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="1"/>
+    </thing>
+  <thing id="bt5CHrFlw2" name="Pursued" description="Nothing can convince me that something isn&apos;t after me somehow." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="2"/>
+    </thing>
+  <thing id="bt5CHrFlw3" name="Superstitious" description="I believe in and try to avoid bad luck." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="3"/>
+    </thing>
+  <thing id="bt5CHrFlw4" name="Secret" description="No one can know the unspeakable things I&apos;ve done." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="4"/>
+    </thing>
+  <thing id="bt5CHrFlw5" name="Gullible" description="I believe almost anything told to me." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="5"/>
+    </thing>
+  <thing id="bt5CHrFlw6" name="Skeptic" description="I don&apos;t believe in anything that can&apos;t be empirically proven to me." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="6"/>
+    </thing>
+  <thing id="bt5CHrIdl1" name="Adrenaline" description="Only strange things excite me." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="1"/>
+    </thing>
+  <thing id="bt5CHrIdl2" name="Balance" description="I make up for the actions of another." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="2"/>
+    </thing>
+  <thing id="bt5CHrIdl3" name="Bound" description="I seek to right a wrong I committed." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="3"/>
+    </thing>
+  <thing id="bt5CHrIdl4" name="Escape" description="There&apos;s something more than the life I know." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="4"/>
+    </thing>
+  <thing id="bt5CHrIdl5" name="Legacy" description="I must be rembered at all costs." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="5"/>
+    </thing>
+  <thing id="bt5CHrIdl6" name="Misdirection" description="No one can know I&apos;m not perfect." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="6"/>
+    </thing>
+  <thing id="bt5CHrPt1" name="Affinity" description="I believe an encounter gave me a special affinity." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="1"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    </thing>
+  <thing id="bt5CHrPt2" name="Signature" description="I wear a unique weapon or piece of clothing." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="2"/>
+    </thing>
+  <thing id="bt5CHrPt3" name="Stubborn" description="Nothing is too much to handle." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="3"/>
+    </thing>
+  <thing id="bt5CHrPt4" name="Inquisitive" description="Leave no stone unturned, no secret hidden." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="4"/>
+    </thing>
+  <thing id="bt5CHrPt5" name="Disingenuous" description="Only those who truly know me know my competence." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="5"/>
+    </thing>
+  <thing id="bt5CHrPt6" name="Collector" description="I collect trophies." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="6"/>
+    </thing>
+  <thing id="bt5CHrPt7" name="Determined" description="I do what&apos;s right, no matter the cost." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="7"/>
+    </thing>
+  <thing id="bt5CHrPt8" name="Dark" description="I&apos;m morbid and macabre" compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="8"/>
+    </thing>
+  <thing id="b5CVRGRHE1" name="Slaughtered" description="Monster that slaughtered dozens of innocent people spared your life." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="1"/>
+    </thing>
+  <thing id="b5CVRGRHE2" name="Dark Star" description="Born under a dark star, you can feel it watching you, coldly and distantly. Sometimes it even beckons you in the dark of night." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="2"/>
+    </thing>
+  <thing id="b5CVRGRHE3" name="Haunted" description="An specter that has haunted your family for generations now haunts you." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="3"/>
+    </thing>
+  <thing id="b5CVRGRHE4" name="Dark Arts" description="Your family has a history of practicing the dark arts. You fled in terror, after dipping your toes into the murky pools of the dark and arcane." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="4"/>
+    </thing>
+  <thing id="b5CVRGRHE5" name="Oni" description="An oni took your sibling one cold, dark night." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="5"/>
+    </thing>
+  <thing id="b5CVRGRHE6" name="Lycanthropy" description="You were cursed with lycanthropy and eventually cured. You are now haunted by the many innocents you slaughtered and fed upon." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="6"/>
+    </thing>
+  <thing id="b5CVRGRHE7" name="Hag" description="A hag raised you after stealing you from your parents. You escaped however, the hag still has a magical hold over you and fills your mind with dark and evil thoughts." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="7"/>
+    </thing>
+  <thing id="b5CVRGRHE8" name="Eldritch Tome" description="You opened an dark arcane tome and saw things unfit for a sane mind. Even burning the book, its words and images are still burned into your mind." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="8"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    </thing>
+  <thing id="b5CVRGRHE9" name="Fiend" description="A fiend possessed you as a young child. You were locked away within your own mind, but managed to escaped. The fiend is still inside you, but now you hope and try to keep it locked away." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="9"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    </thing>
+  <thing id="b5CVRGRHE10" name="Avenge" description="You have done terrible things to avenge the murder of someone you once loved. You have become a monster, and it haunts your every waking dreams." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="10"/>
+    </thing>
+  <thing id="bt5CHrPt9" name="Calm" description="I know how to deal with stress." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="9"/>
+    </thing>
+  <thing id="bt5CHrPt10" name="Stick Together" description="I never leave anyone to die." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="10"/>
+    </thing>
+  <thing id="bt5CHrPt11" name="Extreme" description="I never go with the small, simple solutions." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="11"/>
+    </thing>
+  <thing id="bt5CHrPt12" name="Startled" description="I&apos;m not afraid, but startle easily." compset="BackPerTrt" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="12"/>
+    </thing>
+  <thing id="bt5CHrIdl7" name="Obsession" description="I can&apos;t imagine doing things differently." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="7"/>
+    </thing>
+  <thing id="bt5CHrIdl8" name="Obligation" description="It&apos;s my responsibility to carry on an existing legacy." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="8"/>
+    </thing>
+  <thing id="bt5CHrIdl9" name="Promise" description="I must honor the memory of someone who&apos;s gone." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="9"/>
+    </thing>
+  <thing id="bt5CHrIdl10" name="Revelation" description="I must discover something all but unknowable." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="10"/>
+    </thing>
+  <thing id="bt5CHrIdl11" name="Sanctuary" description="I seek to create a place untouched by those who hold power in the world." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="11"/>
+    </thing>
+  <thing id="bt5CHrIdl12" name="Truth" description="Even if it hurts more than it helps, the truth must be known." compset="BackIdeal" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="12"/>
+    </thing>
+  <thing id="bt5CHrBnd7" name="Lonely" description="I miss someone and surround myself with others like them." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="7"/>
+    </thing>
+  <thing id="bt5CHrBnd8" name="Suppressed" description="I must fight back against evil, within and without." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="8"/>
+    </thing>
+  <thing id="bt5CHrBnd9" name="Desperate" description="I or someone I know desperately needs a cure for something that ails them." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="9"/>
+    </thing>
+  <thing id="bt5CHrBnd10" name="Spirits" description="Spirits seek me because I will help them find peace." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="10"/>
+    </thing>
+  <thing id="bt5CHrBnd11" name="Cunning" description="I solve mysteries and dispense justice." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="11"/>
+    </thing>
+  <thing id="bt5CHrBnd12" name="Haunted" description="Whether real or imagined, I&apos;m haunted by someone I lost." compset="BackBond" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="12"/>
+    </thing>
+  <thing id="bt5CHrFlw7" name="Predestined" description="I believe in fate. Whatever I do will just lead to the same result." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="7"/>
+    </thing>
+  <thing id="bt5CHrFlw8" name="Naive" description="I look for the good in everyone at the cost of ignoring ill intent." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="8"/>
+    </thing>
+  <thing id="bt5CHrFlw9" name="Hesitant" description="Some places are simply evil and shouldn&apos;t be visited." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="9"/>
+    </thing>
+  <thing id="bt5CHrFlw10" name="Prepared" description="I&apos;m overly cautious and have a contingency plan for everything." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="10"/>
+    </thing>
+  <thing id="bt5CHrFlw11" name="Liar" description="My reputation as a great hero was based on a lie, and my enemies know this." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="11"/>
+    </thing>
+  <thing id="bt5CHrFlw12" name="Whatever the Cost" description="I won&apos;t hesitate to make sacrifices for the greater good, even when others question my morality." compset="BackFlaw" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    <tag group="Background" tag="bck5CVRGRHaunt"/>
+    <tag group="Roll" tag="12"/>
+    </thing>
+  <thing id="ab5CVRGRHoD" name="Heart of Darkness" description="You have faced unimaginable horror and that you are no stranger to darkness. Though they might fear you, commoners will extend you every courtesy and do their utmost to help you. They will even take up arms to fght alongside you, should you find yourself facing an enemy alone." compset="Ability">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    <tag group="ProductId" tag="Wizards"/>
+    </thing>
+  <thing id="b5CFC1" name="Acquitted" description="Your first case as a detective was to prove the innocence of a close friend, accused of murder." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="1"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC2" name="Missing" description="Apparently you went missing and have no memory of anything until you were found weeks later. You still don&apos;t know what happened during those weeks." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="2"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC3" name="Laid to Rest" description="You&apos;re well known among spirits for helping lay them to rest." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="3"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC4" name="Hoaxes" description="You exposed an illusionist who harassed your town." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="4"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC5" name="Accused" description="You&apos;ve been wrongfully accused for a crime and are on the run while seeking the true culprit." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="5"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC6" name="Survived" description="Something magical destroyed your home, but you survived. Now you seek to prevent the same thing from happening to others." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="6"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC7" name="Conspiracies" description="You&apos;ve uncovered a massive conspiracy, but nobody believes you -- yet." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="7"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  <thing id="b5CFC8" name="Sleuth" description="Not even law enforcement can solve the cases you help crack." compset="BckCstAbil" uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Roll" tag="8"/>
+    <tag group="Background" tag="bck5CVRGRInvst"/>
+    </thing>
+  </document>

--- a/COM_5ePack_VRGTR - Dark Gifts.user
+++ b/COM_5ePack_VRGTR - Dark Gifts.user
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document signature="Hero Lab Data">
+  <thing id="c5CEchoSl" name="Echoing Soul" description="Your soul wasn&apos;t always entirely yours, and you experience echoes from another life. Roll or choose from the Soul Echoes table." compset="CustomSpec" summary="Your soul is not entirely your own." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CInhrtTng"></bootstrap>
+    <bootstrap thing="ab5CEchChr"></bootstrap>
+    <bootstrap thing="ra5CChnlProw"></bootstrap>
+    <bootstrap thing="ra5CItrsvEch"></bootstrap>
+    </thing>
+  <thing id="ra5CChnlProw" name="Channeled Prowess" description="You gain proficiency in two skills of your choice." compset="RaceSpec">
+    <fieldval field="abValue" value="1"/>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <eval phase="PostLevel" priority="10000"><![CDATA[
+      ~ If we're disabled, do nothing & 
+      doneif (tagis[Helper.Disable] = 1)
+
+      var NumOfSkill as number
+      ~ Increase or decrease the number of proficiencies 
+      NumOfSkill = field[abValue].value
+
+
+      hero.childfound[cfg5CProf].field[cSkillMax2].value += NumOfSkill]]></eval>
+    </thing>
+  <thing id="ra5CInhrtTng" name="Inherent Tongue" description="You can speak, read, and write one more language." compset="RaceSpec">
+    <comment><![CDATA[not sure how to easily implement the scripting on this one as a racial special, I'll get back to it]]></comment>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <bootstrap thing="ra5CDcntLng"></bootstrap>
+    </thing>
+  <thing id="ra5CItrsvEch" name="Intrusive Echoes" description="The first time after a short or long rest that you roll a 1 on the d20, your soul&apos;s memories emerge, causing you to see people as other people or view the world in a disorienting dual state. Roll or choose from the Intrusive Echoes table to determine the effects you experience." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="ab5CEchChr" name="Echoing Soul Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Soul is linked"/>
+    <arrayval field="usrArray" index="1" value="2-Reincarnated many times"/>
+    <arrayval field="usrArray" index="2" value="3-Consciousness transplanted"/>
+    <arrayval field="usrArray" index="3" value="4-Merged with another being"/>
+    <arrayval field="usrArray" index="4" value="5-Body shared with other force"/>
+    <arrayval field="usrArray" index="5" value="6-Time is fractured around you"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CWhsChr" name="Gathered Whispers Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Ancestors watch over you"/>
+    <arrayval field="usrArray" index="1" value="2-Soul sought by fiends"/>
+    <arrayval field="usrArray" index="2" value="3-Souls beg you for peace"/>
+    <arrayval field="usrArray" index="3" value="4-Those you kill haunt you"/>
+    <arrayval field="usrArray" index="4" value="5-Alien intelligence"/>
+    <arrayval field="usrArray" index="5" value="6-Sibling shares your body"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CShdChr" name="Living Shadow Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Additional weapons or wounds"/>
+    <arrayval field="usrArray" index="1" value="2-Panics and wants to escape"/>
+    <arrayval field="usrArray" index="2" value="3-Acts out when not watched"/>
+    <arrayval field="usrArray" index="3" value="4-Imperfect mirror"/>
+    <arrayval field="usrArray" index="4" value="5-Fiddles with or breaks stuff"/>
+    <arrayval field="usrArray" index="5" value="6-Noticable delay when moving"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CWkrChr" name="Mist Walker Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Secret of the Mists"/>
+    <arrayval field="usrArray" index="1" value="2-Fled into the Mists"/>
+    <arrayval field="usrArray" index="2" value="3-Traveler of the Mists"/>
+    <arrayval field="usrArray" index="3" value="4-Stolen by the Mists"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CSknChr" name="Second Skin Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Exaggerated form"/>
+    <arrayval field="usrArray" index="1" value="2-Humanoid beast hybrid form"/>
+    <arrayval field="usrArray" index="2" value="3-Angelic, demonic or aberrant"/>
+    <arrayval field="usrArray" index="3" value="4-human-shaped slime"/>
+    <arrayval field="usrArray" index="4" value="5-fey-like"/>
+    <arrayval field="usrArray" index="5" value="6-stone, metal, or mechanical"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CSmbChr" name="Symbiotic Being Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Face on your torso or hand"/>
+    <arrayval field="usrArray" index="1" value="2-Alien appendage in a wound"/>
+    <arrayval field="usrArray" index="2" value="3-burrowing worm-like being"/>
+    <arrayval field="usrArray" index="3" value="4-Sentient intrusive thought"/>
+    <arrayval field="usrArray" index="4" value="5-Living tattoo"/>
+    <arrayval field="usrArray" index="5" value="6-Crystal growths"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CDthChr" name="Touch of Death Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Infused with chemicals"/>
+    <arrayval field="usrArray" index="1" value="2-Plants and bugs die near you"/>
+    <arrayval field="usrArray" index="2" value="3-Touch damage scars others"/>
+    <arrayval field="usrArray" index="3" value="4-Survived, but shouldn&apos;t have"/>
+    <arrayval field="usrArray" index="4" value="5-Warp things with time"/>
+    <arrayval field="usrArray" index="5" value="6-Hear ominous laughter"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="ab5CWatChr" name="Watchers Characteristics" description="For full text of these options, see Chapter 1 of Van Richten&apos;s Guide to Ravenloft." compset="Ability" uniqueness="unique">
+    <arrayval field="usrArray" index="0" value="1-Carrion Eaters"/>
+    <arrayval field="usrArray" index="1" value="2-Inescapable Judgements"/>
+    <arrayval field="usrArray" index="2" value="3-Night Wings"/>
+    <arrayval field="usrArray" index="3" value="4-Plague Carriers"/>
+    <arrayval field="usrArray" index="4" value="5-Unnatural Observers"/>
+    <arrayval field="usrArray" index="5" value="6-Sea Skulkers"/>
+    <arrayval field="usrArray" index="6" value="7-Stray Souls"/>
+    <arrayval field="usrArray" index="7" value="8-Venomous Vermin"/>
+    <tag group="AbilFunc" tag="Background" name="Background Feature" abbrev="Background Feature"/>
+    </thing>
+  <thing id="c5CGthWhs" name="Gathered Whispers" description="Spirits haunt you, but only you can see them as they whisper in your ear. Roll or choose from the Whispering Spirits table." compset="CustomSpec" summary="Spirits haunt you." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CVRGRSpWh"></bootstrap>
+    <bootstrap thing="ab5CWhsChr"></bootstrap>
+    <bootstrap thing="ra5CSddnCcph"></bootstrap>
+    <bootstrap thing="ra5CVoicBynd"></bootstrap>
+    </thing>
+  <thing id="ra5CVRGRSpWh" name="Spirit Whispers" description="You learn the {i}message{/i} cantrip, and can cast it without any components. Messages are delivered by one of your whispering spirits. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for this spell when you gain this Dark Gift." compset="RaceSpec">
+    <fieldval field="usrCandid1" value="component.BaseAttr &amp; (IsAttr.aWIS | IsAttr.aCHA | IsAttr.aINT)"/>
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="ChooseSrc1" tag="Hero"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="None"/>
+    <tag group="Helper" tag="ActivMenu"/>
+    <bootstrap thing="spMessage">
+      <autotag group="Helper" tag="Free"/>
+      <autotag group="Helper" tag="Memorized"/>
+      </bootstrap>
+    </thing>
+  <thing id="ra5CSddnCcph" name="Sudden Cacophony" description="Once per long rest, you can use your reaction when an attack hits you to let your haunting spirits howl through you. If the attacker can hear you, your proficiency bonus is added to your AC against that attack." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="Reaction"/>
+    </thing>
+  <thing id="ra5CVoicBynd" name="Voices From Beyond" description="The first time after a long rest that you roll a 1 on the d20 for an attack roll, ability check, or saving throw, the voice that haunt you become impossible to ignore. Roll or choose from the Voices From Beyond table to determine the effect theses voices impose on you." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="None"/>
+    </thing>
+  <thing id="ra5CGrspShdw" name="Grasping Shadow" description="You learn the {i}mage hand{/i} cantrip, and can cast it without any components. The hand appears to be made of shadow but is not bound to yours. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for this spell when you gain this Dark Gift." compset="RaceSpec">
+    <fieldval field="usrCandid1" value="component.BaseAttr &amp; (IsAttr.aWIS | IsAttr.aCHA | IsAttr.aINT)"/>
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="ChooseSrc1" tag="Hero"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="None"/>
+    <tag group="Helper" tag="ActivMenu"/>
+    <bootstrap thing="spMageHand">
+      <autotag group="Helper" tag="Free"/>
+      <autotag group="Helper" tag="Memorized"/>
+      </bootstrap>
+    </thing>
+  <thing id="ra5CShdwStrk" name="Shadow Strike" description="You can increase your reach by 10 feet for a number of attacks equal to your proficiency bonus, as your shadow stretches and delivers the attack as if it were you. You regain these uses upon finishing a long rest." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="None"/>
+    </thing>
+  <thing id="ra5COmnsWill" name="Ominous Will" description="The first time after a short or long rest that you roll a 1 on the d20, your shadow exerts its own will. The next time a creature you can see within 30 feet of you (including yourself) makes an attack roll, an ability check, or a saving throw, roll a d4. If the result is odd, reduce the d20 result by that number. If it&apos;s even, increase the d20 result by that much." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="c5CLvgShd" name="Living Shadow" description="Your shadow is always visible and has a mind of its own, moving independently from you. Roll or choose from the Shadow Quirk table." compset="CustomSpec" summary="Your shadow is always visible and moves on its own." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CGrspShdw"></bootstrap>
+    <bootstrap thing="ab5CShdChr"></bootstrap>
+    <bootstrap thing="ra5CShdwStrk"></bootstrap>
+    <bootstrap thing="ra5COmnsWill"></bootstrap>
+    </thing>
+  <thing id="ra5CMistStep" name="Misty Step" description="You learn the {i}misty step{/i} spell, and can cast it without using a spell slot. You may also cast this spell with spell slots of 2nd level or higher. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for this spell when you gain this Dark Gift." compset="RaceSpec">
+    <fieldval field="usrCandid1" value="component.BaseAttr &amp; (IsAttr.aWIS | IsAttr.aCHA | IsAttr.aINT)"/>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <tag group="ChooseSrc1" tag="Hero" name="All Picks on Hero" abbrev="All Picks on Hero"/>
+    <tag group="FeatureTyp" tag="Special" name="Special" abbrev="Special"/>
+    <tag group="abAction" tag="None" name="No action" abbrev="None"/>
+    <tag group="Helper" tag="ActivMenu" name="ActivMenu" abbrev="ActivMenu"/>
+    <tag group="Custom" tag="OnlyIfCaster" name="OnlyIfCaster" abbrev="OnlyIfCaster"/>
+    <bootstrap thing="spMistStep">
+      <autotag group="Helper" tag="Free"/>
+      <autotag group="Helper" tag="Memorized"/>
+      <autotag group="Hide" tag="Spell"/>
+      <autotag group="Custom" tag="OnlyIfCaster"/>
+      </bootstrap>
+    <bootstrap thing="spMistStep">
+      <autotag group="Helper" tag="SpellLike"/>
+      <autotag group="Usage" tag="LongRest"/>
+      <assignval field="trkMax" value="1"/>
+      </bootstrap>
+    <eval phase="Final"><![CDATA[
+doneif (hero.tagis[Hero.Caster] = 0)
+
+foreach pick in hero from BaseSpell where "Custom.OnlyIfCaster"
+  perform eachpick.delete[Hide.Spell]
+  nexteach]]></eval>
+    </thing>
+  <thing id="ra5CMistTrav" name="Mist Traveler" description="When traversing the Mists to reach a particular domain, you are treated as having a Mist talisman keyed to that domain. You need not have visited that domain before, only know its name, however if the domain borders were closed by a Darklord&apos;s will, you cannot bypass those borders." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="None"/>
+    </thing>
+  <thing id="ra5CPsnRoots" name="Poisoned Roots" description="Whenever you finish a long rest, a 10 mile area around where you rested becomes slightly hazardous to you. You may remain in that area safely for a number of weeks equal to your Constitution modifier (minimum 1) . Every time you complete a long rest after that period, you must make a DC 15 Constitution saving throw or gain a level of exhaustion. This level of exhaustion cannot be removed until you leave the area." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec"/>
+    <tag group="FeatureTyp" tag="Special"/>
+    <tag group="abAction" tag="None"/>
+    </thing>
+  <thing id="c5CMstWlk" name="Mist Walker" description="You know how to navigate the Mists, but can&apos;t remain in one place for too long. Roll or choose from the Misty Travels table." compset="CustomSpec" summary="You are adept at traveling the Mists." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CInhrtTng"></bootstrap>
+    <bootstrap thing="ab5CEchChr"></bootstrap>
+    <bootstrap thing="ra5CChnlProw"></bootstrap>
+    <bootstrap thing="ra5CItrsvEch"></bootstrap>
+    </thing>
+  <thing id="ra5CTransform" name="Transformation" description="You learn the {i}alter self{/i} spell, and can cast it once per long rest without using a spell slot. You may also cast this spell with spell slots of 2nd level or higher. When casting this spell, ou may only use the spell&apos;s Change Appearance option, and only change into your second form. When you transform back to your normal form, you retain some aspect of your second form until you complete a long rest, such as scaly skin, stunted wings, eyes without pupils, or horns. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for this spell when you gain this Dark Gift." compset="RaceSpec">
+    <fieldval field="usrCandid1" value="component.BaseAttr &amp; (IsAttr.aWIS | IsAttr.aCHA | IsAttr.aINT)"/>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <tag group="ChooseSrc1" tag="Hero" name="All Picks on Hero" abbrev="All Picks on Hero"/>
+    <tag group="FeatureTyp" tag="Special" name="Special" abbrev="Special"/>
+    <tag group="abAction" tag="None" name="No action" abbrev="None"/>
+    <tag group="Helper" tag="ActivMenu" name="ActivMenu" abbrev="ActivMenu"/>
+    <tag group="Custom" tag="OnlyIfCaster" name="OnlyIfCaster" abbrev="OnlyIfCaster"/>
+    <bootstrap thing="spAlteSelf">
+      <autotag group="Helper" tag="Free"/>
+      <autotag group="Helper" tag="Memorized"/>
+      <autotag group="Hide" tag="Spell"/>
+      <autotag group="Custom" tag="OnlyIfCaster"/>
+      </bootstrap>
+    <bootstrap thing="spAlteSelf">
+      <autotag group="Helper" tag="SpellLike"/>
+      <autotag group="Usage" tag="LongRest"/>
+      <assignval field="trkMax" value="1"/>
+      </bootstrap>
+    <eval phase="Final"><![CDATA[
+doneif (hero.tagis[Hero.Caster] = 0)
+
+foreach pick in hero from BaseSpell where "Custom.OnlyIfCaster"
+  perform eachpick.delete[Hide.Spell]
+  nexteach]]></eval>
+    </thing>
+  <thing id="ra5CInvolChg" name="Involuntary Change" description="Specific situations trigger your Dark Gift. At the start of your next turn after your Dark Gift is triggered in this way, you must make a DC 15 Charisma saving throw or cast {i}alter self{/i} as described in the Transformation trait, even if you cannot normally use it again. Roll or choose from the Change Catalyst table." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="c5CSecSkn" name="Second Skin" description="You can transform into a second, very different form. Roll or choose from the Second Form table." compset="CustomSpec" summary="You have a second form that differs greatly from your own." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CTransform"></bootstrap>
+    <bootstrap thing="ab5CSknChr"></bootstrap>
+    <bootstrap thing="ra5CInvolChg"></bootstrap>
+    </thing>
+  <thing id="ra5CEntwined" name="Entwined Existence" description="You have a symbiote whose separate physical form is bound and dependent on you to survive. It has only the three mental stats, either rolled or chosen by your DM (4d6, drop the lowest if rolled), and experiences the world through your senses. It knows two languages, one that you speak and one appropriate to its nature. The symbiote also grants you proficiency in one of the following skills if you don&apos;t already have it: Arcana, Deception, History, Intimidation, Insight, Nature, Reigion, Perception, or Persuasion. If you die or are returned to life, the symbiote shares this condition." compset="RaceSpec">
+    <comment><![CDATA[not sure how to go about tracking the symbiote's stats. Maybe add a "companion" as a separate hero in the portfolio, like familiars or animal companions?]]></comment>
+    <fieldval field="usrCandid1" value="component.BaseSkill &amp; (Reference.skArcana | Reference.skDecept | Reference.skHistory | Reference.skIntim | Reference.skInsight | Reference.skNature | Reference.skReligion | Reference.skPercep | Reference.skPersuas)"/>
+    <tag group="ChooseSrc1" tag="Thing"/>
+    <tag group="Helper" tag="ActivMenu"/>
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    <eval phase="First"><![CDATA[
+      doneif (tagis[Helper.Disable] <> 0)
+
+      if (field[usrChosen1].ischosen <> 0) then
+        perform field[usrChosen1].chosen.pulltags[ProfSkill.?]
+        endif
+
+      perform forward[ProfSkill.?]]]></eval>
+    </thing>
+  <thing id="c5CSmbBng" name="Symbiotic Being" description="A symbiotic being is merged with you and depends on you for survival. Roll or choose from the Symbiotic Nature table." compset="CustomSpec" summary="You host a symbiote." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CEntwined"></bootstrap>
+    <bootstrap thing="ab5CSmbChr"></bootstrap>
+    <bootstrap thing="ra5CSustSymb"></bootstrap>
+    <bootstrap thing="ra5CSymbAgnd"></bootstrap>
+    </thing>
+  <thing id="ra5CSustSymb" name="Sustained Symbiosis" description="Your symbiote takes extra measures to keep you alive. If you fail a saving throw, it can expend one of your Hit Dice, rolls it, and adds the rseult to your saving throw. If it does this for a death saving throw, it doesn&apos;t matter what you rolled on the d20, you automatically succeed and regain 1 hit point. Once your symbiote helps you succeed on one saving throw, it cannot assist in this manner again until you finish a long rest." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="ra5CSymbAgnd" name="Symbiotic Agenda" description="Your symbiote has some driving goal, and it wants you to help accomplish it. Your DM determines how patient or permissive it is, as that depends on its personality, but if you have an opportunity to help further its cause and you don&apos;t act on it, the symbiote can try to charm you into doing so. You must succeed on a Charisma saving throw (DC) or become charmed and follow its commands for 1d12 hours. Taking damage that&apos;s not self-inflicted allows you to make another saving throw, ending the effect on a success. Roll or choose from the Symbiotic Agenda table." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="ra5CDeathTch" name="Death Touch" description="Make an unarmed strike as an action. In addition to the normal damage, you deal 1d10 necrotic damage, 2d10 necrotic damage if you&apos;re at least 5th level, 3d10 if you&apos;re at least 11th level, or 4d10 if you&apos;re 17th level." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="ra5CInescDth" name="Inescapable Death" description="You ignore a target&apos;s resistance to necrotic damage." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="ra5CWithCont" name="Withering Contact" description="If you start a turn either grapling or being grappled by another creature, that creature takes 1d10 necrotic damage." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="c5CTchDth" name="Touch of Death" description="Physical contact with you harms others. Roll or choose from the Deadly Touch table." compset="CustomSpec" summary="You exude necrotic energy." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ra5CDeathTch"></bootstrap>
+    <bootstrap thing="ab5CDthChr"></bootstrap>
+    <bootstrap thing="ra5CInescDth"></bootstrap>
+    <bootstrap thing="ra5CWithCont"></bootstrap>
+    </thing>
+  <thing id="ra5CBrwdEyes" name="Borrowed Eyes" description="As an action, you can affect the creatures that watch you. Doing so gives you advantage on any Investigation and Perception checks and it becomes impossible to blind you for the duration. You can only use this ability once per long rest." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="ra5CDreadPrs" name="Dread Presence" description="You have disadvantage on Deception, Performance, and Persuasion checks against creatures that can see your watchers, as well as saving throws against any attempt to scry on you with the {i}scrying{/i} spell. With 1 minute of effort and a successful DC 15 Animal Handling check, you can suppress both this effect and Borrowed Eyes. This suppression lasts for 1 hour, and cannot be done again until you complete a long rest." compset="RaceSpec">
+    <tag group="Helper" tag="ShowSpec" name="Show Spec" abbrev="Show Spec"/>
+    </thing>
+  <thing id="c5CWatchr" name="Watchers" description="Shadowy creatures gather around you, serving as eyes for something else to watch you. Roll or choose from the Watchers table." compset="CustomSpec" summary="Small shadowy creatures follow you around, watching you." uniqueness="unique">
+    <usesource source="5eVRGtR"/>
+    <tag group="Helper" tag="SpecUp" name="SpecUp" abbrev="SpecUp"/>
+    <tag group="Helper" tag="Quaternary"/>
+    <tag group="AllowRCust" tag="cfg5CSupGif" name="Dark Gifts" abbrev="Dark Gifts"/>
+    <bootstrap thing="ab5CWatChr"></bootstrap>
+    <bootstrap thing="ra5CBrwdEyes"></bootstrap>
+    <bootstrap thing="ra5CDreadPrs"></bootstrap>
+    </thing>
+  </document>


### PR DESCRIPTION
Missed this branch of the repository, wrote more than I needed to, trimmed it down to just Backgrounds and Dark Gifts. Entwined Existence still needs a way to track the symbiote's stats, Inherent Tongue still needs a way to add a language, and I didn't know of a way to give each each Dark Gift their special roll table.