### PR TITLE
Adding bootstrap for po5cOccMnd to d5CTelCont as it was missing

### DIFF
--- a/COM_5ePack_UA - Mystic.user
+++ b/COM_5ePack_UA - Mystic.user
@@ -4395,6 +4395,10 @@ endif]]></eval>
       <autotag group="Helper" tag="PsiLike"/>
       <autotag group="Helper" tag="SpellLike"/>
       </bootstrap>
+    <bootstrap thing="po5cOccMnd">
+      <autotag group="Helper" tag="PsiLike"/>
+      <autotag group="Helper" tag="SpellLike"/>
+      </bootstrap>
     <bootstrap thing="po5cBrkWil">
       <autotag group="Helper" tag="SpellLike"/>
       </bootstrap>


### PR DESCRIPTION
First time editing a HeroLab file so hopefully I've got this right. 

Occluded Mind wasn't showing up in my char's list of psi spells, and I noticed it wasn't grouped under Telepathic Contact so have added it in.

Couldn't find any contribution rules, so forgive the scrappiest of PRs from me. Have tested locally on one machine and it now appears in my spell list and compile builds with no errors for me.